### PR TITLE
ci: report test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,34 @@ jobs:
       - name: Analyze
         run: flutter analyze --fatal-infos
 
-      - name: Run tests
-        run: flutter test --timeout 60s
+      - name: Run tests (with coverage)
+        run: flutter test --coverage --timeout 60s
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/lcov.info ]; then
+            awk -F: '
+              /^LF:/ { lf += $2 }
+              /^LH:/ { lh += $2 }
+              END {
+                pct = (lf > 0) ? (lh / lf) * 100 : 0
+                printf "Line coverage: %.1f%% (%d/%d lines)\n", pct, lh, lf
+                if (ENVIRON["GITHUB_STEP_SUMMARY"] != "")
+                  printf "### Coverage: %.1f%% (%d/%d lines)\n", pct, lh, lf \
+                    >> ENVIRON["GITHUB_STEP_SUMMARY"]
+              }' coverage/lcov.info
+          else
+            echo "coverage/lcov.info not found"
+          fi
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: warn
 
       - name: Publish dry-run
         run: dart pub publish --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ migrate_working_dir/
 **/doc/api/
 .dart_tool/
 build/
+
+# Test coverage output
+coverage/

--- a/REVIEW_ACTION_PLAN.md
+++ b/REVIEW_ACTION_PLAN.md
@@ -151,7 +151,7 @@ Severity: 9/10 — **SELESAI**. `flutter test` = **+295 All tests passed**, EXIT
 
 - [x] `flutter analyze --fatal-infos` = 0 issue (lebih ketat dari `--fatal-warnings`)
 - [x] `flutter test` hijau (**321 lulus**)
-- [ ] Coverage dilaporkan — **belum**; CI belum jalankan `--coverage`/upload (follow-up cepat)
+- [x] Coverage dilaporkan — CI jalankan `flutter test --coverage`, tampilkan `%` di job summary + upload `coverage/lcov.info` sebagai artifact. Baseline saat ini **~48.9%** (676/1383 baris).
 - [ ] `dart pub publish --dry-run` lolos — **belum**; masih ketahan *hint* nama `flutter_core` sudah dipakai di pub.dev (perlu rename)
 - [x] CI hijau di GitHub Actions (PR #7 & #8)
 - [x] README & example compile terhadap API nyata
@@ -167,4 +167,4 @@ Severity: 9/10 — **SELESAI**. `flutter test` = **+295 All tests passed**, EXIT
 
 ## Sisa pekerjaan (opsional / rilis)
 - Opsional: singleton → DI (arsitektural, butuh keputusan), `ThemeProvider.setColorScheme` no-op, string `genericError` hardcoded, semantik null-success.
-- Rilis: coverage di CI, rename package, bump versi 2.0.0.
+- Rilis: ~~coverage di CI~~ ✅, rename package, bump versi 2.0.0.


### PR DESCRIPTION
Adds coverage reporting to CI: `flutter test --coverage`, line-% in the job summary (awk-parsed, no `bc`), and `coverage/lcov.info` uploaded as an artifact. Baseline ~48.9%. Also gitignores `coverage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)