### PR TITLE
refactor!: rename identifiers to match values + review fixes (v3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 3.0.0 — 2026-06-21
+
+### Breaking Changes — identifier renames
+
+Public identifiers were renamed so each name reflects its value/role. Update call sites accordingly:
+
+- `FlutterCore.localStorage` → `FlutterCore.secureStorage`; `FlutterCore.cleanup()` → `resetInitialization()`
+- `ThemeProvider.setThemeMode(bool)` → `setDarkMode(bool)`
+- `Failure.error` field → `Failure.cause` (all subclasses + `NetworkException`)
+- `ConnectivityService.getCurrentConnectivity()` → `getCurrentConnectivityResults()`
+- `DioClient.authToken` getter → `authorizationHeader` (returns the `Bearer …` header)
+- `ColorSchemes.purple/orange/darkBlue/darkGreen` → `…Scheme`
+- Date ext: `toDbFormat` → `toIsoDate`, `toDateTime` → `toIndonesianDateTimeString`, `toIndonesiandMMMyyyy` → `toShortMonthNameWithDay`
+- Number ext: `toFormattedString` → `toGroupedDigits`
+- String ext: `toRemove62` → `withoutCountryCode62`, `toPhoneNumber62` → `toIndonesianPhoneDigits`, `jsonDecode` → `decodedJson`
+- `BuildContext.accentIconTheme` → `secondaryIconTheme`; `canBack` → `canGoBack`; `withOpacity` → `colorWithOpacity`
+- Num ext: `paddingX/paddingY` → `paddingHorizontal/paddingVertical`, `radiusX` → `radiusHorizontal`
+- TextStyle ext: `heightSpace` → `withLineHeight`, `letterSpace` → `withLetterSpacing`
+- Map ext: `get(key)` → `valueOrNull(key)`
+- `UiHelper.shadow` → `defaultBoxShadow`; `insetAxis(x,y)` → `insetSymmetric(horizontal,vertical)`; `visualDensity(x,y)` → `visualDensity(horizontal,vertical)`
+- `kDelayed` (one-shot future) → `defaultDelay()` (returns a fresh delay each call)
+- `SecureStorage.deleteBoxFromDisk()` removed (use `clearBox()`)
+- Extensions renamed from `…X` to descriptive names (`IterableX` → `NullableIterableExtension`, `StreamX` → `StreamExtension`, etc.)
+
+### Fixes
+- `BuildContext.isWeb` now uses `kIsWeb` (previously always reported Linux).
+- `ThemeData` is now built with the custom `ColorScheme` directly, so scheme-derived
+  colors (scaffold/app bar) match `FcColors`.
+- Token refresh inherits client timeouts and clears the stale auth header when refresh fails.
+- Logging interceptor redacts `Authorization`/`Cookie` headers and truncates bodies.
+- `ThousandsFormatter` formats values beyond the `int` range and honors `allowNegative`.
+- `SecureStorage.get<bool>` returns `null` for corrupt values instead of silently `false`.
+- `defaultDelay()` delays on every call; stream `debounce`/`throttle` no longer leak the source subscription.
+
+---
+
 ## 2.0.0 — 2026-06-20
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Public identifiers were renamed so each name reflects its value/role. Update cal
 - `FlutterCore.localStorage` → `FlutterCore.secureStorage`; `FlutterCore.cleanup()` → `resetInitialization()`
 - `ThemeProvider.setThemeMode(bool)` → `setDarkMode(bool)`
 - `Failure.error` field → `Failure.cause` (all subclasses + `NetworkException`)
+- `Result` failure variant `Error` → `ResultError` (avoids shadowing `dart:core.Error`)
 - `ConnectivityService.getCurrentConnectivity()` → `getCurrentConnectivityResults()`
 - `DioClient.authToken` getter → `authorizationHeader` (returns the `Bearer …` header)
 - `ColorSchemes.purple/orange/darkBlue/darkGreen` → `…Scheme`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Public identifiers were renamed so each name reflects its value/role. Update cal
 - Num ext: `paddingX/paddingY` → `paddingHorizontal/paddingVertical`, `radiusX` → `radiusHorizontal`
 - TextStyle ext: `heightSpace` → `withLineHeight`, `letterSpace` → `withLetterSpacing`
 - Map ext: `get(key)` → `valueOrNull(key)`
+- Navigation ext: `maybeBack` → `popToRoot`; `isDialogOpen` → `isCoveredByRoute`; `closeDialog` → `dismissTopRoute`
+- Stream ext: `debounceMs(int)`/`throttleMs(int)` → `debounce(Duration)`/`throttle(Duration)`
 - `UiHelper.shadow` → `defaultBoxShadow`; `insetAxis(x,y)` → `insetSymmetric(horizontal,vertical)`; `visualDensity(x,y)` → `visualDensity(horizontal,vertical)`
 - `kDelayed` (one-shot future) → `defaultDelay()` (returns a fresh delay each call)
 - `SecureStorage.deleteBoxFromDisk()` removed (use `clearBox()`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to flutter_core
+# Contributing to flutter_corekit
 
 ## Getting Started
 
@@ -23,7 +23,7 @@
 - No commented-out code in production files — delete or use a separate branch
 - No development notes in source (`// TODO added for feature X`, emoji markers)
 - Extensions go in `lib/src/extensions/` with corresponding test in `test/extensions/`
-- New public API must be exported from `lib/flutter_core.dart`
+- New public API must be exported from `lib/flutter_corekit.dart`
 - Follow existing naming: snake_case files, PascalCase classes, camelCase methods
 
 ## Adding a New Extension

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add to your `pubspec.yaml`:
 dependencies:
   flutter_corekit:
     git:
-      url: https://github.com/antsf/flutter_core
+      url: https://github.com/antsf/flutter_corekit
       ref: main
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ context.isDarkMode
 
 ```dart
 searchController.stream
-  .debounceMs(300)   // wait 300ms of silence
-  .throttleMs(500)   // emit at most once per 500ms
+  .debounce(const Duration(milliseconds: 300))   // wait 300ms of silence
+  .throttle(const Duration(milliseconds: 500))   // emit at most once per 500ms
 ```
 
 ### Result Type

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class MyApp extends StatelessWidget {
       listenable: ThemeProvider.instance,
       builder: (context, _) => MaterialApp(
         // ThemeProvider exposes a single already-resolved theme; toggle it with
-        // ThemeProvider.instance.toggleTheme() / setThemeMode(bool).
+        // ThemeProvider.instance.toggleTheme() / setDarkMode(bool).
         theme: ThemeProvider.instance.currentTheme,
         home: const HomePage(),
       ),
@@ -138,7 +138,7 @@ DateTime.now().toIndonesianDate()        // "26 Juni 2025"
 DateTime.now().toShortMonthName()        // "26 Jun 2025"
 DateTime.now().toIndonesianDateWithDay() // "Kamis, 26 Juni 2025"
 DateTime.now().toTime()                  // "14:30"
-DateTime.now().toDbFormat()              // "2025-06-26"
+DateTime.now().toIsoDate()               // "2025-06-26"
 ```
 
 #### Numbers (Rupiah)
@@ -193,7 +193,7 @@ context.isDarkMode
 1.spacing        // SizedBox(16x16)
 2.spacingHeight  // SizedBox(height: 32)
 1.padding        // EdgeInsets.all(16)
-1.paddingX       // EdgeInsets.symmetric(horizontal: 16)
+1.paddingHorizontal // EdgeInsets.symmetric(horizontal: 16)
 0.5.radius       // BorderRadius.circular(5)
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,8 +30,8 @@ void main() async {
   );
 
   // Initialize the SecureStorage service before use
-  final localStorage = SecureStorage();
-  await localStorage.init();
+  final secureStorage = SecureStorage();
+  await secureStorage.init();
 
   // Example of providing a custom dark theme
   final customDarkTheme = AppTheme.defaultDarkTheme.copyWith(
@@ -79,7 +79,7 @@ class _HomePageState extends State<HomePage> {
   String response = '';
   bool isLoading = false;
 
-  final localStorage = SecureStorage();
+  final secureStorage = SecureStorage();
 
   Future<void> loadData() async {
     setState(() => isLoading = true);
@@ -98,12 +98,12 @@ class _HomePageState extends State<HomePage> {
   }
 
   void localStorageVoid() async {
-    await localStorage.set<String>('prefs', 'token', 'abc123');
-    final token = await localStorage.get<String>('prefs', 'token');
+    await secureStorage.set<String>('prefs', 'token', 'abc123');
+    final token = await secureStorage.get<String>('prefs', 'token');
     if (token.isNotNullOrEmpty) {
-      await localStorage.set('prefs', 'token', token!);
+      await secureStorage.set('prefs', 'token', token!);
     }
-    await localStorage.delete('prefs', 'token');
+    await secureStorage.delete('prefs', 'token');
   }
 
   @override

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -1,6 +1,6 @@
 /// Exports core functionalities, services, and UI utilities for Flutter applications.
 ///
-/// This library serves as the main entry point for the `flutter_core` package.
+/// This library serves as the main entry point for the `flutter_corekit` package.
 /// It provides the [FlutterCore] class for initializing essential services like
 /// networking and storage, and the [ScreenUtilWrapper] widget for setting up
 /// responsive UI utilities.
@@ -19,9 +19,6 @@
 ///
 ///   // Initialize Flutter Core services (e.g., network, storage).
 ///   await FlutterCore.initialize(baseUrl: 'https://api.example.com');
-///
-///   // Optionally, initialize UI-specific services like themes and fonts.
-///   await FlutterCore.initializeUI();
 ///
 ///   runApp(MyApp());
 /// }
@@ -56,11 +53,10 @@ import 'src/services/connectivity_service.dart';
 
 /// Main class for initializing and accessing core functionalities of the Flutter Core package.
 ///
-/// This class provides static methods to initialize services like networking ([dioClient]),
-/// secure storage ([storageService]), and UI theming ([themeProvider]).
+/// This class provides static methods to initialize services like networking
+/// ([dioClient]) and secure storage ([secureStorage]).
 ///
 /// The [initialize] method **must** be called before accessing any services.
-/// The [initializeUI] method can be called to set up themes and fonts.
 ///
 /// Accessing services before initialization will result in a [LateInitializationError].
 class FlutterCore {
@@ -78,7 +74,7 @@ class FlutterCore {
   ///
   /// Available after [initialize] has been successfully called.
   /// Throws a [LateInitializationError] if accessed before initialization.
-  static late final SecureStorage localStorage;
+  static late final SecureStorage secureStorage;
 
   /// Initializes core non-UI services of the Flutter Core package.
   ///
@@ -111,8 +107,8 @@ class FlutterCore {
     }
 
     // 1. Initialize secure storage.
-    localStorage = SecureStorage();
-    await localStorage.init();
+    secureStorage = SecureStorage();
+    await secureStorage.init();
 
     // 2. Initialize the network client (Dio).
     dioClient = DioClient(
@@ -147,12 +143,12 @@ class FlutterCore {
   /// Primarily for testing, where services may need re-initialization between
   /// tests.
   ///
-  /// **Note:** the `late final` static fields (`dioClient`, `localStorage`)
+  /// **Note:** the `late final` static fields (`dioClient`, `secureStorage`)
   /// cannot be reset without restarting the app or a proper DI container, so
   /// this only resets the `_isInitialized` flag.
-  static Future<void> cleanup() async {
+  static Future<void> resetInitialization() async {
     if (!_isInitialized) {
-      debugPrint("FlutterCore.cleanup() called but core is not initialized.");
+      debugPrint("FlutterCore.resetInitialization() called but core is not initialized.");
       return;
     }
 

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -148,7 +148,8 @@ class FlutterCore {
   /// this only resets the `_isInitialized` flag.
   static Future<void> resetInitialization() async {
     if (!_isInitialized) {
-      debugPrint("FlutterCore.resetInitialization() called but core is not initialized.");
+      debugPrint(
+          "FlutterCore.resetInitialization() called but core is not initialized.");
       return;
     }
 

--- a/lib/src/constants/colors.dart
+++ b/lib/src/constants/colors.dart
@@ -233,6 +233,9 @@ class FcColors {
         onErrorContainer: onErrorContainer,
         surface: surface,
         onSurface: onSurface,
+        // The neutral [background] (Grey 50) is intentionally reused as the
+        // container tone: a subtle step below the white [surface] (M3 merged the
+        // old `background` role into surface, so this constant has no other home).
         surfaceContainer: background,
         surfaceContainerHighest: surfaceVariant,
         onSurfaceVariant: onSurfaceVariant,

--- a/lib/src/constants/colors.dart
+++ b/lib/src/constants/colors.dart
@@ -164,7 +164,7 @@ class FcColors {
   /// [color]: The original color.
   /// [opacity]: The opacity value, ranging from 0.0 (fully transparent) to 1.0 (fully opaque).
   /// Returns a new [Color] instance with the applied opacity.
-  static Color withOpacity(Color color, double opacity) {
+  static Color colorWithOpacity(Color color, double opacity) {
     return color.withValues(alpha: opacity);
   }
 
@@ -238,8 +238,9 @@ class FcColors {
         onSurfaceVariant: onSurfaceVariant,
         outline: outline,
         outlineVariant: outlineVariant,
-        // Inverse colors can be added if needed, e.g.,
-        inversePrimary: onPrimary,
+        // Inverse colors: a lighter, tinted primary reads as a "primary" on the
+        // dark inverse surface (white — the previous `onPrimary` — did not).
+        inversePrimary: primaryLight,
         inverseSurface: onSurface,
         onInverseSurface: surface,
         shadow: Colors.black, // Default shadow color

--- a/lib/src/constants/default.dart
+++ b/lib/src/constants/default.dart
@@ -36,19 +36,19 @@ double get kBottomNavigationBarHeight => 56.h;
 /// Returns `56.h`, which means 56 logical pixels scaled vertically by `ScreenUtil`.
 double get kAppBarHeight => 56.h;
 
-/// A pre-created `Future` that completes after `kDuration`.
+/// Returns a fresh `Future` that completes after [kDuration].
 ///
-/// This can be used for simple delays in UI logic or animations.
-/// However, for more complex scenarios or multiple delays, creating `Future.delayed`
-/// instances on demand might be more appropriate to avoid potential reuse issues
-/// if the future is expected to run multiple times.
+/// Use this for simple delays in UI logic or animations. It is a function (not a
+/// cached field) so every call produces a new delay — `await defaultDelay()` always
+/// waits the full [kDuration], whereas a single shared future would only delay
+/// the first awaiter and return immediately thereafter.
 ///
 /// Example:
 /// ```dart
-/// await kDelayed; // Waits for kDuration (300ms)
+/// await defaultDelay(); // Waits for kDuration (300ms)
 /// // Perform action after delay
 /// ```
-final Future<void> kDelayed = Future.delayed(kDuration);
+Future<void> defaultDelay() => Future.delayed(kDuration);
 
 /// A 1x1 transparent PNG image represented as a `Uint8List`.
 ///

--- a/lib/src/extensions/color_scheme_ext.dart
+++ b/lib/src/extensions/color_scheme_ext.dart
@@ -51,8 +51,8 @@ extension ColorContextExtensions on BuildContext {
 
   Color get transparentColor => FcColors.transparent;
 
-  Color withOpacity(Color color, double opacity) =>
-      FcColors.withOpacity(color, opacity);
+  Color colorWithOpacity(Color color, double opacity) =>
+      FcColors.colorWithOpacity(color, opacity);
   Color darken(Color color, [double amount = 0.1]) =>
       FcColors.darken(color, amount);
   Color lighten(Color color, [double amount = 0.1]) =>

--- a/lib/src/extensions/date_ext.dart
+++ b/lib/src/extensions/date_ext.dart
@@ -40,13 +40,13 @@ extension IndonesianDate on DateTime {
   }
 
   /// Formats the date with the full day of the week and time (e.g., `Kamis, 26 Jun 2025 14:30`).
-  String toIndonesiandMMMyyyy() {
+  String toShortMonthNameWithDay() {
     initialize();
     return DateFormat('EEEE, d MMM yyyy', 'id_ID').format(this);
   }
 
   /// Formats the date with full month name and time (e.g., `26 Juni 2025 14:30`).
-  String toDateTime() {
+  String toIndonesianDateTimeString() {
     initialize();
     return DateFormat('d MMMM yyyy HH:mm', 'id_ID').format(this);
   }
@@ -88,7 +88,7 @@ extension IndonesianDate on DateTime {
   }
 
   /// Formats the date for a database (e.g., `2025-06-26`).
-  String toDbFormat() {
+  String toIsoDate() {
     initialize();
     return DateFormat('yyyy-MM-dd').format(this);
   }

--- a/lib/src/extensions/iterable_ext.dart
+++ b/lib/src/extensions/iterable_ext.dart
@@ -1,4 +1,4 @@
-extension IterableX<T> on Iterable<T>? {
+extension NullableIterableExtension<T> on Iterable<T>? {
   /// true if null OR empty
   bool get isNullOrEmpty => this == null || this?.isEmpty == true;
 

--- a/lib/src/extensions/map_ext.dart
+++ b/lib/src/extensions/map_ext.dart
@@ -1,6 +1,6 @@
 import 'dart:convert' show JsonEncoder;
 
-extension MapX<K, V> on Map<K, V>? {
+extension NullableMapExtension<K, V> on Map<K, V>? {
   /// true if null OR empty
   bool get isNullOrEmpty => this == null || this?.isEmpty == true;
 
@@ -8,7 +8,7 @@ extension MapX<K, V> on Map<K, V>? {
   bool get isNotNullOrEmpty => !isNullOrEmpty;
 
   /// Get value or null safely
-  V? get(K key) => this?[key];
+  V? valueOrNull(K key) => this?[key];
 
   /// Pretty-print with indent
   String pretty() {

--- a/lib/src/extensions/navigation_ext.dart
+++ b/lib/src/extensions/navigation_ext.dart
@@ -102,12 +102,12 @@ extension NavigationExtension on BuildContext {
   /// Wraps `Navigator.canPop(this)`.
   bool canGoBack() => Navigator.canPop(this);
 
-  /// Pops all routes until the initial route.
-  /// If a [result] is provided, it's passed to the pop method for each route.
+  /// Pops every route until the initial (root) route is reached.
+  /// If a [result] is provided, it's passed to each pop.
   ///
-  /// **Caution**: This will pop all routes above the very first route in the stack.
-  /// Ensure this is the desired behavior.
-  void maybeBack<T extends Object?>([T? result]) {
+  /// **Caution**: this pops *all* routes above the first one in the stack — it is
+  /// not a single conditional pop. Use [back] for that.
+  void popToRoot<T extends Object?>([T? result]) {
     while (canGoBack()) {
       back<T>(result);
     }
@@ -141,19 +141,20 @@ extension NavigationExtension on BuildContext {
 
   // --- Dialogs & Modals ---
 
-  /// Checks if a dialog is currently open over this context.
+  /// Whether this context's route is currently covered by another route on top
+  /// (e.g. a dialog, bottom sheet, or pushed page).
   ///
-  /// This is a heuristic and might not be universally accurate for all types of
-  /// modal routes or dialog implementations. It checks if the current route
-  /// associated with this context is the topmost active route.
-  bool get isDialogOpen => ModalRoute.of(this)?.isCurrent != true;
+  /// This is a heuristic: it reports `true` whenever this route is not the
+  /// topmost active route. It cannot tell *what* is on top (dialog vs. page).
+  bool get isCoveredByRoute => ModalRoute.of(this)?.isCurrent != true;
 
-  /// Attempts to close an open dialog if [isDialogOpen] is true.
+  /// Pops the topmost route if this context's route is [isCoveredByRoute]
+  /// (commonly used to dismiss an open dialog/bottom sheet).
   ///
-  /// Uses [back] to pop the current route, which is assumed to be a dialog.
-  /// See caveats for [isDialogOpen].
-  void closeDialog() {
-    if (isDialogOpen) {
+  /// See the caveats on [isCoveredByRoute] — it dismisses whatever is on top,
+  /// not specifically a dialog.
+  void dismissTopRoute() {
+    if (isCoveredByRoute) {
       back();
     }
   }

--- a/lib/src/extensions/navigation_ext.dart
+++ b/lib/src/extensions/navigation_ext.dart
@@ -100,7 +100,7 @@ extension NavigationExtension on BuildContext {
   /// Checks if the navigator can be popped.
   ///
   /// Wraps `Navigator.canPop(this)`.
-  bool canBack() => Navigator.canPop(this);
+  bool canGoBack() => Navigator.canPop(this);
 
   /// Pops all routes until the initial route.
   /// If a [result] is provided, it's passed to the pop method for each route.
@@ -108,7 +108,7 @@ extension NavigationExtension on BuildContext {
   /// **Caution**: This will pop all routes above the very first route in the stack.
   /// Ensure this is the desired behavior.
   void maybeBack<T extends Object?>([T? result]) {
-    while (canBack()) {
+    while (canGoBack()) {
       back<T>(result);
     }
   }

--- a/lib/src/extensions/nullable_ext.dart
+++ b/lib/src/extensions/nullable_ext.dart
@@ -1,4 +1,4 @@
-extension NullableX<T> on T? {
+extension NullableExtension<T> on T? {
   /// Run block if value is NOT null
   R? let<R>(R Function(T) block) => this == null ? null : block(this as T);
 

--- a/lib/src/extensions/number_ext.dart
+++ b/lib/src/extensions/number_ext.dart
@@ -22,7 +22,11 @@ extension IndonesianCurrency on num {
     return toString();
   }
 
-  /// Short informal Rupiah format. Example: `1500000` → `Rp 1,5jt`.
+  /// Short informal Rupiah format. Example: `1500000` → `Rp 1.5jt`,
+  /// `50000` → `Rp 50rb`.
+  ///
+  /// The fractional part uses a `.` separator (it is not locale-formatted);
+  /// the `< 1000` fallback uses Indonesian thousand grouping.
   String toShortRupiah() {
     if (this >= 1000000) {
       final value = this / 1000000;
@@ -47,7 +51,7 @@ extension IndonesianCurrency on num {
   /// Formats with thousand separators. Defaults to Indonesian locale (`id_ID`).
   ///
   /// Example (id_ID): `1000` → `1.000`
-  String toFormattedString({String locale = 'id_ID'}) {
+  String toGroupedDigits({String locale = 'id_ID'}) {
     final fmt = NumberFormat.decimalPattern(locale);
     return fmt.format(this);
   }

--- a/lib/src/extensions/stream_ext.dart
+++ b/lib/src/extensions/stream_ext.dart
@@ -1,26 +1,37 @@
 import 'dart:async';
 
 /// Stream utility extensions — debounce and throttle without external dependencies.
-extension StreamX<T> on Stream<T> {
+extension StreamExtension<T> on Stream<T> {
   /// Emits a value only after [ms] milliseconds of silence (no new events).
   Stream<T> debounceMs(int ms) {
     final controller = StreamController<T>.broadcast();
     Timer? timer;
-    listen(
-      (event) {
-        timer?.cancel();
-        timer = Timer(Duration(milliseconds: ms), () {
-          if (!controller.isClosed) controller.add(event);
-        });
-      },
-      onError: (Object e, StackTrace s) {
-        if (!controller.isClosed) controller.addError(e, s);
-      },
-      onDone: () {
-        timer?.cancel();
-        controller.close();
-      },
-    );
+    StreamSubscription<T>? sub;
+    // Subscribe to the source lazily (on first listen) and tear it down when
+    // the downstream cancels, so the source isn't subscribed forever / leaked.
+    controller.onListen = () {
+      sub = listen(
+        (event) {
+          timer?.cancel();
+          timer = Timer(Duration(milliseconds: ms), () {
+            if (!controller.isClosed) controller.add(event);
+          });
+        },
+        onError: (Object e, StackTrace s) {
+          if (!controller.isClosed) controller.addError(e, s);
+        },
+        onDone: () {
+          timer?.cancel();
+          controller.close();
+        },
+      );
+    };
+    controller.onCancel = () {
+      timer?.cancel();
+      final pending = sub?.cancel();
+      sub = null;
+      return pending;
+    };
     return controller.stream;
   }
 
@@ -28,19 +39,27 @@ extension StreamX<T> on Stream<T> {
   Stream<T> throttleMs(int ms) {
     final controller = StreamController<T>.broadcast();
     bool throttled = false;
-    listen(
-      (event) {
-        if (!throttled) {
-          throttled = true;
-          if (!controller.isClosed) controller.add(event);
-          Timer(Duration(milliseconds: ms), () => throttled = false);
-        }
-      },
-      onError: (Object e, StackTrace s) {
-        if (!controller.isClosed) controller.addError(e, s);
-      },
-      onDone: () => controller.close(),
-    );
+    StreamSubscription<T>? sub;
+    controller.onListen = () {
+      sub = listen(
+        (event) {
+          if (!throttled) {
+            throttled = true;
+            if (!controller.isClosed) controller.add(event);
+            Timer(Duration(milliseconds: ms), () => throttled = false);
+          }
+        },
+        onError: (Object e, StackTrace s) {
+          if (!controller.isClosed) controller.addError(e, s);
+        },
+        onDone: () => controller.close(),
+      );
+    };
+    controller.onCancel = () {
+      final pending = sub?.cancel();
+      sub = null;
+      return pending;
+    };
     return controller.stream;
   }
 }

--- a/lib/src/extensions/stream_ext.dart
+++ b/lib/src/extensions/stream_ext.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 /// Stream utility extensions — debounce and throttle without external dependencies.
 extension StreamExtension<T> on Stream<T> {
-  /// Emits a value only after [ms] milliseconds of silence (no new events).
-  Stream<T> debounceMs(int ms) {
+  /// Emits a value only after [duration] of silence (no new events).
+  Stream<T> debounce(Duration duration) {
     final controller = StreamController<T>.broadcast();
     Timer? timer;
     StreamSubscription<T>? sub;
@@ -13,7 +13,7 @@ extension StreamExtension<T> on Stream<T> {
       sub = listen(
         (event) {
           timer?.cancel();
-          timer = Timer(Duration(milliseconds: ms), () {
+          timer = Timer(duration, () {
             if (!controller.isClosed) controller.add(event);
           });
         },
@@ -35,8 +35,8 @@ extension StreamExtension<T> on Stream<T> {
     return controller.stream;
   }
 
-  /// Emits the first event then ignores subsequent events for [ms] milliseconds.
-  Stream<T> throttleMs(int ms) {
+  /// Emits the first event then ignores subsequent events for [duration].
+  Stream<T> throttle(Duration duration) {
     final controller = StreamController<T>.broadcast();
     bool throttled = false;
     StreamSubscription<T>? sub;
@@ -46,7 +46,7 @@ extension StreamExtension<T> on Stream<T> {
           if (!throttled) {
             throttled = true;
             if (!controller.isClosed) controller.add(event);
-            Timer(Duration(milliseconds: ms), () => throttled = false);
+            Timer(duration, () => throttled = false);
           }
         },
         onError: (Object e, StackTrace s) {

--- a/lib/src/extensions/string_ext.dart
+++ b/lib/src/extensions/string_ext.dart
@@ -71,13 +71,13 @@ extension StringExt on String {
   }
 
   /// Removes the `62` country code prefix, if present.
-  String toRemove62() {
+  String withoutCountryCode62() {
     if (startsWith('62')) return substring(2);
     return this;
   }
 
   /// Parses a JSON string into a Dart [Map] or [List].
-  dynamic get jsonDecode => json.decode(this);
+  dynamic get decodedJson => json.decode(this);
 
   /// Capitalizes the first letter. Example: `hello` → `Hello`.
   String get capitalize =>
@@ -113,7 +113,7 @@ extension StringExt on String {
 extension StringNullExt on String? {
   /// Converts to Indonesian phone format starting with `62`.
   /// Returns empty string if null.
-  String toPhoneNumber62() {
+  String toIndonesianPhoneDigits() {
     final digits = this?.replaceAll(RegExp(r'\D'), '') ?? '';
     if (digits.isEmpty) return '';
 

--- a/lib/src/extensions/text_style_ext.dart
+++ b/lib/src/extensions/text_style_ext.dart
@@ -37,10 +37,10 @@ extension TextStyleExtension on TextStyle {
   TextStyle fontSize(double value) => copyWith(fontSize: value.sp);
 
   /// Returns a new [TextStyle] with the specified line [value] (line spacing).
-  TextStyle heightSpace(double value) => copyWith(height: value);
+  TextStyle withLineHeight(double value) => copyWith(height: value);
 
   /// Returns a new [TextStyle] with the specified letter [value].
-  TextStyle letterSpace(double value) => copyWith(letterSpacing: value);
+  TextStyle withLetterSpacing(double value) => copyWith(letterSpacing: value);
 
   /// Returns a new [TextStyle] with the specified [color].
   TextStyle withColor(Color color) => copyWith(color: color);

--- a/lib/src/extensions/ui_ext.dart
+++ b/lib/src/extensions/ui_ext.dart
@@ -1,6 +1,7 @@
 /// UI and device adaptation extension methods for BuildContext and num.
 library;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -73,8 +74,8 @@ extension BuildContextExtension on BuildContext {
   /// Gets the primary icon theme data from the current theme.
   IconThemeData get primaryIconTheme => theme.primaryIconTheme;
 
-  /// Gets the accent icon theme data from the current theme.
-  IconThemeData get accentIconTheme =>
+  /// An icon theme derived from the color scheme's secondary color (at 70% alpha).
+  IconThemeData get secondaryIconTheme =>
       IconThemeData(color: theme.colorScheme.secondary.withValues(alpha: .7));
 
   /// Gets the input decoration theme from the current theme.
@@ -155,8 +156,11 @@ extension BuildContextExtension on BuildContext {
   /// Checks if the platform is Fuchsia.
   bool get isFuchsia => platform == TargetPlatform.fuchsia;
 
-  /// Checks if the platform is Web. Note: This check is not ideal; consider using `kIsWeb` for better accuracy.
-  bool get isWeb => platform == TargetPlatform.linux;
+  /// Checks if the app is running on the web.
+  ///
+  /// Uses the compile-time constant `kIsWeb`, which is the only reliable way to
+  /// detect web. (`platform` reports the host OS even in a browser.)
+  bool get isWeb => kIsWeb;
 
   /// Checks if the platform is a desktop operating system.
   bool get isDesktop => isMacOS || isWindows || isLinux;
@@ -184,8 +188,11 @@ extension BuildContextExtension on BuildContext {
   /// Checks if the device is a foldable phone.
   bool get isFoldable => isAndroid && screenWidth >= 600 && screenWidth < 800;
 
-  /// Checks if the device is a wearable device.
-  bool get isWearable => isWatch || isTV || isCar || isFoldable;
+  /// Checks if the device is a wearable device (i.e. a watch).
+  ///
+  /// Note: TVs, car displays, and foldables are distinct form factors — use
+  /// [isTV], [isCar], and [isFoldable] for those.
+  bool get isWearable => isWatch;
 
   /// Checks if the device is a handheld device (phone or tablet).
   bool get isHandheld => isPhone || isTablet;
@@ -249,7 +256,7 @@ extension NumExtension on num {
   EdgeInsets get padding => EdgeInsets.all((this * kPadding).w);
 
   /// Returns [EdgeInsets] with horizontal sides as multiples of [kPadding].
-  EdgeInsets get paddingX =>
+  EdgeInsets get paddingHorizontal =>
       EdgeInsets.symmetric(horizontal: (this * kPadding).w);
 
   /// Returns [EdgeInsets] with a left padding as a multiple of [kPadding].
@@ -265,14 +272,14 @@ extension NumExtension on num {
   EdgeInsets get paddingBottom => EdgeInsets.only(bottom: (this * kPadding).w);
 
   /// Returns [EdgeInsets] with horizontal sides as multiples of [kPadding].
-  EdgeInsets get paddingY =>
+  EdgeInsets get paddingVertical =>
       EdgeInsets.symmetric(vertical: (this * kPadding).w);
 
   /// Returns a [BorderRadius] with all corners as multiples of [kRadius].
   BorderRadius get radius => BorderRadius.circular((this * kRadius).r);
 
   /// Returns a [BorderRadius.horizontal] with all corners as multiples of [kRadius].
-  BorderRadius get radiusX =>
+  BorderRadius get radiusHorizontal =>
       BorderRadius.horizontal(left: cornerRadius, right: cornerRadius);
 
   /// Returns a [BorderRadius.top] with all corners as multiples of [kRadius].
@@ -288,7 +295,7 @@ extension NumExtension on num {
 /// --- EdgeInsets Extensions ---
 /// (Scaling)
 /// Extension methods for [EdgeInsets] to provide scaling.
-extension EdgeInsetsX on EdgeInsets {
+extension EdgeInsetsScaleExtension on EdgeInsets {
   /// Returns a scaled [EdgeInsets] using [ScreenUtil].
   EdgeInsets get scaled =>
       copyWith(left: left.w, right: right.w, top: top.h, bottom: bottom.h);
@@ -297,7 +304,7 @@ extension EdgeInsetsX on EdgeInsets {
 /// --- BorderRadius Extensions ---
 /// (Scaling)
 /// Extension methods for [BorderRadius] to provide scaling.
-extension BorderRadiusX on BorderRadius {
+extension BorderRadiusScaleExtension on BorderRadius {
   /// Returns a scaled [BorderRadius] using [ScreenUtil].
   BorderRadius get scaled => BorderRadius.only(
         topLeft: Radius.circular(topLeft.x.r),

--- a/lib/src/extensions/widget_ext.dart
+++ b/lib/src/extensions/widget_ext.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_corekit/src/extensions/ui_ext.dart';
 
 /// Extensions on `List<Widget>`.
-extension ListWidgetX on List<Widget> {
+extension WidgetListExtension on List<Widget> {
   /// Adds [separator] between every existing widget
   List<Widget> separatedBy(Widget separator) {
     if (isEmpty) return this;
@@ -56,7 +56,7 @@ extension ListWidgetX on List<Widget> {
 }
 
 /// Extensions on a single Widget
-extension WidgetX on Widget {
+extension SingleWidgetExtension on Widget {
   /// Returns a list containing only this widget
   List<Widget> get asList => [this];
 

--- a/lib/src/network/api_response.dart
+++ b/lib/src/network/api_response.dart
@@ -72,7 +72,8 @@ class ApiResponse<T> {
   ///
   /// The success value is nullable (`T?`) to honour empty 204 responses; the
   /// failure is the same [Failure] carried by [error].
-  Result<T?, Failure> toResult() => isFailure ? Error(error!) : Success(data);
+  Result<T?, Failure> toResult() =>
+      isFailure ? ResultError(error!) : Success(data);
 
   @override
   String toString() => isSuccessful

--- a/lib/src/network/dio_client.dart
+++ b/lib/src/network/dio_client.dart
@@ -278,7 +278,8 @@ class DioClient {
 
   void clearHeaders() => _dio.options.headers.clear();
 
-  String? get authorizationHeader => _dio.options.headers['Authorization'] as String?;
+  String? get authorizationHeader =>
+      _dio.options.headers['Authorization'] as String?;
 
   /// Direct access to the underlying [Dio] instance. Use with caution.
   Dio get dioInstance => _dio;

--- a/lib/src/network/dio_client.dart
+++ b/lib/src/network/dio_client.dart
@@ -278,7 +278,7 @@ class DioClient {
 
   void clearHeaders() => _dio.options.headers.clear();
 
-  String? get authToken => _dio.options.headers['Authorization'] as String?;
+  String? get authorizationHeader => _dio.options.headers['Authorization'] as String?;
 
   /// Direct access to the underlying [Dio] instance. Use with caution.
   Dio get dioInstance => _dio;
@@ -286,14 +286,14 @@ class DioClient {
   // --- Private ---
 
   Future<ApiResponse<T>> _execute<T>(
-    Future<Response<dynamic>> Function() call, {
+    Future<Response<dynamic>> Function() request, {
     T Function(dynamic)? fromJson,
     String? cacheKey,
     Duration? cacheTtl,
   }) async {
     try {
       if (_checkConnectivityBeforeRequest) await _checkConnectivity();
-      final response = await call();
+      final response = await request();
       final rawData = response.data;
       if (cacheKey != null && cacheTtl != null && rawData != null) {
         _writeCacheEntry(cacheKey, _CacheEntry(rawData, cacheTtl));
@@ -341,11 +341,11 @@ class DioClient {
     // Scope every cache key to the current identity (auth token) so a cached
     // response for one user can never be served to another after the token
     // changes. The token itself is not stored — only its hash.
-    final identity = _dio.options.headers['Authorization']?.hashCode ?? 0;
-    final base = (query == null || query.isEmpty)
+    final authHash = _dio.options.headers['Authorization']?.hashCode ?? 0;
+    final keyBody = (query == null || query.isEmpty)
         ? path
         : '$path?${(query.entries.toList()..sort((a, b) => a.key.compareTo(b.key))).map((e) => '${e.key}=${e.value}').join('&')}';
-    return '$identity|$base';
+    return '$authHash|$keyBody';
   }
 
   /// Reads a cache entry, applying LRU semantics: a valid hit is moved to
@@ -403,7 +403,12 @@ class DioClient {
                 error.requestOptions.extra['__retried_after_refresh'] = true;
                 return handler.resolve(await _dio.fetch(error.requestOptions));
               }
-              _logger?.w('DioClient: Token refresh returned null.');
+              // Refresh definitively failed to produce a token: the current
+              // token is invalid, so drop it instead of leaving a stale
+              // Authorization header on every subsequent request.
+              _logger?.w(
+                  'DioClient: Token refresh returned null. Clearing stale auth token.');
+              clearAuthToken();
             } catch (e, s) {
               _logger?.e('DioClient: Token refresh failed.',
                   error: e, stackTrace: s);
@@ -429,7 +434,14 @@ class DioClient {
   Future<String?> _refreshAuthToken(Future<String?> Function(Dio) callback) {
     return _ongoingRefresh ??= () async {
       try {
-        final dioForRefresh = Dio(BaseOptions(baseUrl: _dio.options.baseUrl));
+        // Inherit the main client's timeouts so a hung refresh endpoint can't
+        // stall all coalesced 401 callers indefinitely.
+        final dioForRefresh = Dio(BaseOptions(
+          baseUrl: _dio.options.baseUrl,
+          connectTimeout: _dio.options.connectTimeout,
+          receiveTimeout: _dio.options.receiveTimeout,
+          sendTimeout: _dio.options.sendTimeout,
+        ));
         return await callback(dioForRefresh);
       } finally {
         _ongoingRefresh = null;

--- a/lib/src/network/dio_interceptor.dart
+++ b/lib/src/network/dio_interceptor.dart
@@ -8,6 +8,29 @@ library;
 import 'package:dio/dio.dart';
 import 'package:logger/logger.dart'; // Assuming 'logger' package is used
 
+/// Header names whose values are secrets and must never be logged verbatim.
+const _sensitiveHeaders = <String>{
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'proxy-authorization',
+};
+
+/// Returns the header value, or `<redacted>` for sensitive headers so tokens
+/// and cookies don't leak into logs.
+String redactedHeaderValue(String key, Object? value) =>
+    _sensitiveHeaders.contains(key.toLowerCase()) ? '<redacted>' : '$value';
+
+/// Stringifies a request/response body, truncating long payloads (which often
+/// contain PII) to [maxLength] characters.
+String _truncateBody(Object? data, [int maxLength = 1000]) {
+  final text = data.toString();
+  return text.length > maxLength
+      ? '${text.substring(0, maxLength)}… (${text.length} chars total)'
+      : text;
+}
+
 /// A [Dio] interceptor that logs HTTP requests, responses, and errors.
 ///
 /// This interceptor can be useful for debugging network interactions during development.
@@ -55,12 +78,11 @@ class DioLoggingInterceptor extends Interceptor {
       logMessage.writeln('URI: ${options.uri}');
       if (options.headers.isNotEmpty) {
         logMessage.writeln('Headers:');
-        options.headers
-            .forEach((key, value) => logMessage.writeln('  $key: $value'));
+        options.headers.forEach((key, value) =>
+            logMessage.writeln('  $key: ${redactedHeaderValue(key, value)}'));
       }
       if (options.data != null) {
-        logMessage.writeln('Data: ${options.data}');
-        // 'Data: ${options.data.toString().length > 200 ? "${options.data.toString().substring(0, 200)}..." : options.data}');
+        logMessage.writeln('Data: ${_truncateBody(options.data)}');
       }
       logMessage.write('-------------------');
       logger!.i(logMessage.toString());
@@ -80,8 +102,7 @@ class DioLoggingInterceptor extends Interceptor {
       logMessage.writeln('Status Code: ${response.statusCode}');
       logMessage.writeln('Status Message: ${response.statusMessage}');
       if (response.data != null) {
-        logMessage.writeln('Data: ${response.data}');
-        // 'Data: ${response.data.toString().length > 200 ? "${response.data.toString().substring(0, 200)}..." : response.data}');
+        logMessage.writeln('Data: ${_truncateBody(response.data)}');
       }
       logMessage.write('--------------------');
       logger!.i(logMessage.toString());
@@ -105,8 +126,8 @@ class DioLoggingInterceptor extends Interceptor {
         logMessage.writeln('Status Code: ${err.response!.statusCode}');
         logMessage.writeln('Status Message: ${err.response!.statusMessage}');
         if (err.response!.data != null) {
-          logMessage.writeln(
-              'Response Data: ${err.response!.data.toString().length > 200 ? "${err.response!.data.toString().substring(0, 200)}..." : err.response!.data}');
+          logMessage
+              .writeln('Response Data: ${_truncateBody(err.response!.data)}');
         }
       }
       logMessage.write('-----------------');

--- a/lib/src/network/dio_retry_interceptor.dart
+++ b/lib/src/network/dio_retry_interceptor.dart
@@ -58,7 +58,8 @@ class RetryOptions {
     final rawDelayMs = useExponentialBackoff
         ? baseDelayMs * pow(2, (attempt - 1).clamp(0, 30))
         : baseDelayMs;
-    final cappedDelayMs = (rawDelayMs > maxDelayMs ? maxDelayMs : rawDelayMs).toInt();
+    final cappedDelayMs =
+        (rawDelayMs > maxDelayMs ? maxDelayMs : rawDelayMs).toInt();
     if (!useJitter || cappedDelayMs <= 0) return cappedDelayMs;
     // Equal jitter: keep half the delay fixed, randomize the other half.
     final halfDelayMs = cappedDelayMs ~/ 2;

--- a/lib/src/network/dio_retry_interceptor.dart
+++ b/lib/src/network/dio_retry_interceptor.dart
@@ -55,14 +55,14 @@ class RetryOptions {
 
   /// Computes the delay (ms) before the given 1-based [attempt].
   int calculateDelay(int attempt) {
-    final raw = useExponentialBackoff
+    final rawDelayMs = useExponentialBackoff
         ? baseDelayMs * pow(2, (attempt - 1).clamp(0, 30))
         : baseDelayMs;
-    final capped = (raw > maxDelayMs ? maxDelayMs : raw).toInt();
-    if (!useJitter || capped <= 0) return capped;
+    final cappedDelayMs = (rawDelayMs > maxDelayMs ? maxDelayMs : rawDelayMs).toInt();
+    if (!useJitter || cappedDelayMs <= 0) return cappedDelayMs;
     // Equal jitter: keep half the delay fixed, randomize the other half.
-    final half = capped ~/ 2;
-    return half + _retryRandom.nextInt(capped - half + 1);
+    final halfDelayMs = cappedDelayMs ~/ 2;
+    return halfDelayMs + _retryRandom.nextInt(cappedDelayMs - halfDelayMs + 1);
   }
 }
 

--- a/lib/src/network/exceptions/network_exceptions.dart
+++ b/lib/src/network/exceptions/network_exceptions.dart
@@ -14,7 +14,7 @@ import '../../result/failures.dart';
 ///
 /// Implements [Exception] to be throwable.
 /// Each [NetworkException] carries a user-friendly [message], an optional
-/// HTTP [statusCode], the original [error] (often a [DioException]), and
+/// HTTP [statusCode], the original [cause] (often a [DioException]), and
 /// an optional [stackTrace].
 ///
 /// The factory constructor `NetworkException.fromDioException` is provided to
@@ -34,12 +34,12 @@ abstract class NetworkException extends Failure implements Exception {
   const NetworkException({
     required String message,
     int? statusCode,
-    Object? error,
+    Object? cause,
     StackTrace? stackTrace,
   }) : super(
           message: message,
           statusCode: statusCode ?? 0,
-          error: error,
+          cause: cause,
           stackTrace: stackTrace,
         );
 
@@ -51,8 +51,8 @@ abstract class NetworkException extends Failure implements Exception {
     if (statusCode != 0) {
       sb.write(' (Status Code: $statusCode)');
     }
-    if (error != null && error is DioException) {
-      sb.write(' URL: ${(error as DioException).requestOptions.uri}');
+    if (cause != null && cause is DioException) {
+      sb.write(' URL: ${(cause as DioException).requestOptions.uri}');
     }
     return sb.toString();
   }
@@ -99,12 +99,12 @@ abstract class NetworkException extends Failure implements Exception {
       apiMessage = responseData;
     }
 
-    final specificMessage = _getDefaultMessage(statusCode);
+    final defaultMessage = _getDefaultMessage(statusCode);
 
     // Prioritize the API message if it's available and not empty.
     final finalMessage = (apiMessage != null && apiMessage.isNotEmpty)
         ? apiMessage
-        : specificMessage;
+        : defaultMessage;
 
     if (statusCode == null) {
       return ServerException(dioException: dioException);
@@ -227,7 +227,7 @@ class NetworkTimeoutException extends NetworkException {
           message:
               'The network request timed out. Please check your connection and try again.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -240,7 +240,7 @@ class NoInternetConnectionException extends NetworkException {
           message:
               'No internet connection. Please check your network settings and try again.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -254,7 +254,7 @@ class ServerException extends NetworkException {
           message: specificMessage ??
               'A server error occurred. Please try again later.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -270,7 +270,7 @@ class ClientErrorException extends NetworkException {
           message: specificMessage ??
               'There was an issue with the request (Client Error).',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -285,7 +285,7 @@ class UnauthorizedException extends NetworkException {
           message: specificMessage ??
               'Unauthorized: Authentication credentials were missing or incorrect.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -300,7 +300,7 @@ class ForbiddenException extends NetworkException {
           message: specificMessage ??
               'Forbidden: The request is understood, but it has been refused or access is not allowed.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -315,7 +315,7 @@ class NotFoundException extends NetworkException {
           message: specificMessage ??
               'Not Found: The requested resource could not be found.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -330,7 +330,7 @@ class MethodNotAllowedException extends NetworkException {
           message: specificMessage ??
               'Method Not Allowed: The request was made to a resource using an HTTP request method not supported by that resource.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -345,7 +345,7 @@ class RequestTimeoutException extends NetworkException {
           message: specificMessage ??
               'Request Timeout: The server timed out waiting for the request.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -360,7 +360,7 @@ class ConflictException extends NetworkException {
           message: specificMessage ??
               'Conflict: The request could not be completed due to a conflict with the current state of the resource.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -375,7 +375,7 @@ class TooManyRequestsException extends NetworkException {
           message: specificMessage ??
               'Too Many Requests: The user has sent too many requests in a given amount of time.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -390,7 +390,7 @@ class InternalServerErrorException extends NetworkException {
           message: specificMessage ??
               'Internal Server Error: The server encountered an unexpected condition that prevented it from fulfilling the request.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -405,7 +405,7 @@ class NotImplementedException extends NetworkException {
           message: specificMessage ??
               'Not Implemented: The server does not support the functionality required to fulfill the request.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -420,7 +420,7 @@ class BadGatewayException extends NetworkException {
           message: specificMessage ??
               'Bad Gateway: The server was acting as a gateway or proxy and received an invalid response from the upstream server.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -435,7 +435,7 @@ class ServiceUnavailableException extends NetworkException {
           message: specificMessage ??
               'Service Unavailable: The server is currently unavailable.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -450,7 +450,7 @@ class GatewayTimeoutException extends NetworkException {
           message: specificMessage ??
               'Gateway Timeout: The server was acting as a gateway or proxy and did not receive a timely response from the upstream server.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -461,7 +461,7 @@ class CancelledException extends NetworkException {
   CancelledException({required DioException dioException})
       : super(
           message: 'The network request was cancelled.',
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }
@@ -476,7 +476,7 @@ class UnknownNetworkException extends NetworkException {
           message: specificMessage ??
               'An unknown network error occurred. Please try again.',
           statusCode: dioException.response?.statusCode,
-          error: dioException,
+          cause: dioException,
           stackTrace: dioException.stackTrace,
         );
 }

--- a/lib/src/network/safe_remote_call.dart
+++ b/lib/src/network/safe_remote_call.dart
@@ -41,7 +41,8 @@ FutureResult<R?> safeRemoteCall<T, R>({
       if (onSuccess != null) return Success(onSuccess(data as T));
       return const Success(null);
     } else {
-      return Error(result.failure ?? GenericFailure(message: fallbackErrorMessage));
+      return Error(
+          result.failure ?? GenericFailure(message: fallbackErrorMessage));
     }
   } on NetworkException catch (e) {
     // NetworkException is a Failure — return it directly, preserving its

--- a/lib/src/network/safe_remote_call.dart
+++ b/lib/src/network/safe_remote_call.dart
@@ -30,7 +30,7 @@ FutureResult<R?> safeRemoteCall<T, R>({
   required RemoteCall<T> remoteCall,
   R Function(T)? onSuccess,
   void Function(T)? onBeforeSuccess,
-  String genericError = 'Terjadi kesalahan tak terduga',
+  String fallbackErrorMessage = 'Terjadi kesalahan tak terduga',
 }) async {
   try {
     final result = await remoteCall();
@@ -41,7 +41,7 @@ FutureResult<R?> safeRemoteCall<T, R>({
       if (onSuccess != null) return Success(onSuccess(data as T));
       return const Success(null);
     } else {
-      return Error(result.failure ?? GenericFailure(message: genericError));
+      return Error(result.failure ?? GenericFailure(message: fallbackErrorMessage));
     }
   } on NetworkException catch (e) {
     // NetworkException is a Failure — return it directly, preserving its
@@ -61,13 +61,13 @@ FutureResult<R?> safeRemoteCall<T, R>({
 FutureResult<void> safeRemoteCallVoid<T>({
   required RemoteCall<T> remoteCall,
   void Function(T)? onBeforeSuccess,
-  String genericError = 'Terjadi kesalahan tak terduga',
+  String fallbackErrorMessage = 'Terjadi kesalahan tak terduga',
 }) async {
   final result = await safeRemoteCall<T, void>(
     remoteCall: remoteCall,
     onSuccess: null,
     onBeforeSuccess: onBeforeSuccess,
-    genericError: genericError,
+    fallbackErrorMessage: fallbackErrorMessage,
   );
   return result;
 }

--- a/lib/src/network/safe_remote_call.dart
+++ b/lib/src/network/safe_remote_call.dart
@@ -41,21 +41,21 @@ FutureResult<R?> safeRemoteCall<T, R>({
       if (onSuccess != null) return Success(onSuccess(data as T));
       return const Success(null);
     } else {
-      return Error(
+      return ResultError(
           result.failure ?? GenericFailure(message: fallbackErrorMessage));
     }
   } on NetworkException catch (e) {
     // NetworkException is a Failure — return it directly, preserving its
     // specific type (Unauthorized/NotFound/...) instead of flattening it.
     _logError('NetworkException: ${e.message}');
-    return Error(e);
+    return ResultError(e);
   } on DioException catch (e) {
     final networkException = NetworkException.fromDioException(e);
     _logError('DioException: ${networkException.message}');
-    return Error(networkException);
+    return ResultError(networkException);
   } catch (e) {
     _logError('Unexpected error: $e');
-    return Error(GenericFailure(message: e.toString()));
+    return ResultError(GenericFailure(message: e.toString()));
   }
 }
 

--- a/lib/src/result/failures.dart
+++ b/lib/src/result/failures.dart
@@ -3,22 +3,22 @@ import 'package:flutter/foundation.dart';
 /// A base class for all failures in the application.
 ///
 /// Enforces value equality and provides a standard structure for failure
-/// information, including a message, the original error, and a stack trace.
+/// information, including a message, the original cause, and a stack trace.
 @immutable
 abstract class Failure {
   final String message;
-  final dynamic error;
+  final dynamic cause;
   final StackTrace? stackTrace;
   final int statusCode;
 
   const Failure({
     required this.message,
-    this.error,
+    this.cause,
     this.stackTrace,
     this.statusCode = 0,
   });
 
-  List<Object?> get props => [message, error, stackTrace, statusCode];
+  List<Object?> get props => [message, cause, stackTrace, statusCode];
 
   @override
   bool operator ==(Object other) =>
@@ -32,14 +32,14 @@ abstract class Failure {
 
   @override
   String toString() =>
-      '$runtimeType(message: $message, error: $error, statusCode: $statusCode)';
+      '$runtimeType(message: $message, cause: $cause, statusCode: $statusCode)';
 }
 
 /// Represents a failure related to server operations (e.g., 5xx errors).
 class ServerFailure extends Failure {
   const ServerFailure({
     required super.message,
-    super.error,
+    super.cause,
     super.stackTrace,
     super.statusCode,
   });
@@ -49,7 +49,7 @@ class ServerFailure extends Failure {
 class NetworkFailure extends Failure {
   const NetworkFailure({
     required super.message,
-    super.error,
+    super.cause,
     super.stackTrace,
     super.statusCode,
   });
@@ -59,7 +59,7 @@ class NetworkFailure extends Failure {
 class CacheFailure extends Failure {
   const CacheFailure({
     required super.message,
-    super.error,
+    super.cause,
     super.stackTrace,
     super.statusCode,
   });
@@ -69,7 +69,7 @@ class CacheFailure extends Failure {
 class AuthFailure extends Failure {
   const AuthFailure({
     required super.message,
-    super.error,
+    super.cause,
     super.stackTrace,
     super.statusCode,
   });
@@ -81,7 +81,7 @@ class ValidationFailure extends Failure {
 
   const ValidationFailure({
     required this.errors,
-    super.error,
+    super.cause,
     super.stackTrace,
     super.statusCode,
   }) : super(message: 'One or more validation errors occurred.');
@@ -94,7 +94,7 @@ class ValidationFailure extends Failure {
 class GenericFailure extends Failure {
   const GenericFailure({
     required super.message,
-    super.error,
+    super.cause,
     super.stackTrace,
     super.statusCode,
   });

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -1,7 +1,8 @@
 import 'failures.dart';
 
 /// Represents the result of an operation that can either succeed with [T] or
-/// fail with a [Failure]. Use [Success] and [Error] as concrete implementations.
+/// fail with a [Failure]. Use [Success] and [ResultError] as concrete
+/// implementations.
 abstract class Result<T, F> {
   const Result();
   bool get isSuccess;
@@ -23,9 +24,11 @@ class Success<T, F> extends Result<T, F> {
   F? get failure => null;
 }
 
-class Error<T, F> extends Result<T, F> {
+/// The failure variant of a [Result]. Named `ResultError` (not `Error`) to
+/// avoid shadowing `dart:core`'s [Error].
+class ResultError<T, F> extends Result<T, F> {
   final F error;
-  const Error(this.error);
+  const ResultError(this.error);
   @override
   bool get isSuccess => false;
   @override
@@ -64,7 +67,7 @@ extension ResultExtension<T, F> on Result<T, F> {
     if (this is Success<T, F>) {
       return onSuccess((this as Success<T, F>).value);
     } else {
-      return onFailure((this as Error<T, F>).error);
+      return onFailure((this as ResultError<T, F>).error);
     }
   }
 
@@ -73,13 +76,13 @@ extension ResultExtension<T, F> on Result<T, F> {
     if (this is Success<T, F>) {
       return Success(transform((this as Success<T, F>).value));
     }
-    return Error((this as Error<T, F>).error);
+    return ResultError((this as ResultError<T, F>).error);
   }
 
   /// Transforms the failure value, leaving successes untouched.
   Result<T, G> mapFailure<G>(G Function(F failure) transform) {
-    if (this is Error<T, F>) {
-      return Error(transform((this as Error<T, F>).error));
+    if (this is ResultError<T, F>) {
+      return ResultError(transform((this as ResultError<T, F>).error));
     }
     return Success((this as Success<T, F>).value);
   }

--- a/lib/src/services/connectivity_service.dart
+++ b/lib/src/services/connectivity_service.dart
@@ -91,7 +91,7 @@ class ConnectivityService {
   /// This method provides a snapshot of the current connection state(s).
   /// Returns a list of [ConnectivityResult]s.
   /// On error, logs the error and returns an empty list.
-  Future<List<ConnectivityResult>> getCurrentConnectivity() async {
+  Future<List<ConnectivityResult>> getCurrentConnectivityResults() async {
     try {
       return await _connectivity.checkConnectivity();
     } catch (e, stackTrace) {

--- a/lib/src/storage/secure_storage.dart
+++ b/lib/src/storage/secure_storage.dart
@@ -120,9 +120,6 @@ class SecureStorage {
     return result;
   }
 
-  /// Alias for [clearBox] — removes all keys under [boxName].
-  Future<void> deleteBoxFromDisk(String boxName) async => clearBox(boxName);
-
   /* ---------- private ---------- */
 
   String _key(String boxName, String key) => '$boxName|$key';
@@ -136,7 +133,14 @@ class SecureStorage {
     if (T == String) return raw as T;
     if (T == int) return int.tryParse(raw) as T?;
     if (T == double) return double.tryParse(raw) as T?;
-    if (T == bool) return (raw.toLowerCase() == 'true') as T;
+    if (T == bool) {
+      final lower = raw.toLowerCase();
+      if (lower == 'true') return true as T;
+      if (lower == 'false') return false as T;
+      // Corrupt/garbage value — return null like the other tryParse branches
+      // instead of silently coercing to `false`.
+      return null;
+    }
     if (T == Map<String, dynamic>) return jsonDecode(raw) as T?;
     if (T == List<dynamic>) return jsonDecode(raw) as T?;
     throw UnsupportedError(

--- a/lib/src/theme/color_schemes.dart
+++ b/lib/src/theme/color_schemes.dart
@@ -34,7 +34,7 @@ class ColorSchemes {
       );
 
   /// Purple color scheme
-  static ColorScheme get purple => const ColorScheme.light(
+  static ColorScheme get purpleScheme => const ColorScheme.light(
         primary: Color(0xFF6A1B9A),
         secondary: Color(0xFF9C27B0),
         surface: Colors.white,
@@ -47,7 +47,7 @@ class ColorSchemes {
       );
 
   /// Orange color scheme
-  static ColorScheme get orange => const ColorScheme.light(
+  static ColorScheme get orangeScheme => const ColorScheme.light(
         primary: Color(0xFFE65100),
         secondary: Color(0xFFFF9800),
         surface: Colors.white,
@@ -60,7 +60,7 @@ class ColorSchemes {
       );
 
   /// Dark blue color scheme
-  static ColorScheme get darkBlue => const ColorScheme.dark(
+  static ColorScheme get darkBlueScheme => const ColorScheme.dark(
         primary: Color(0xFF1565C0),
         secondary: Color(0xFF1976D2),
         surface: Color(0xFF121212),
@@ -73,7 +73,7 @@ class ColorSchemes {
       );
 
   /// Dark green color scheme
-  static ColorScheme get darkGreen => const ColorScheme.dark(
+  static ColorScheme get darkGreenScheme => const ColorScheme.dark(
         primary: Color(0xFF1B5E20),
         secondary: Color(0xFF2E7D32),
         surface: Color(0xFF121212),

--- a/lib/src/theme/text_theme.dart
+++ b/lib/src/theme/text_theme.dart
@@ -14,7 +14,7 @@ typedef FontBuilder = TextStyle Function(
     double? letterSpacing});
 
 // Default uses Google Fonts
-FontBuilder _defaultFont = (
+FontBuilder _fontStyleBuilder = (
         {double? fontSize,
         FontWeight? fontWeight,
         Color? color,
@@ -27,7 +27,7 @@ FontBuilder _defaultFont = (
 
 // Allow test to replace it
 void setFontBuilderForTesting(FontBuilder builder) {
-  _defaultFont = builder;
+  _fontStyleBuilder = builder;
 }
 
 /// Text theme configurations
@@ -35,7 +35,7 @@ class TextThemes {
   TextThemes._();
 
   // Font weights
-  static const FontWeight lightW = FontWeight.w300;
+  static const FontWeight lightWeight = FontWeight.w300;
   static const FontWeight regular = FontWeight.w400;
   static const FontWeight medium = FontWeight.w500;
   static const FontWeight semiBold = FontWeight.w600;
@@ -43,54 +43,54 @@ class TextThemes {
 
   /// Creates a base text theme
   static TextTheme get base => TextTheme(
-        displayLarge: _defaultFont(fontSize: 57.sp, fontWeight: bold),
-        displayMedium: _defaultFont(fontSize: 45.sp, fontWeight: bold),
-        displaySmall: _defaultFont(fontSize: 36.sp, fontWeight: bold),
-        headlineLarge: _defaultFont(fontSize: 32.sp, fontWeight: semiBold),
-        headlineMedium: _defaultFont(fontSize: 28.sp, fontWeight: semiBold),
-        headlineSmall: _defaultFont(fontSize: 22.sp, fontWeight: semiBold),
-        titleLarge: _defaultFont(
+        displayLarge: _fontStyleBuilder(fontSize: 57.sp, fontWeight: bold),
+        displayMedium: _fontStyleBuilder(fontSize: 45.sp, fontWeight: bold),
+        displaySmall: _fontStyleBuilder(fontSize: 36.sp, fontWeight: bold),
+        headlineLarge: _fontStyleBuilder(fontSize: 32.sp, fontWeight: semiBold),
+        headlineMedium: _fontStyleBuilder(fontSize: 28.sp, fontWeight: semiBold),
+        headlineSmall: _fontStyleBuilder(fontSize: 22.sp, fontWeight: semiBold),
+        titleLarge: _fontStyleBuilder(
             fontSize: 18.sp,
             letterSpacing: 0,
             color: FcColors.primaryText,
             fontWeight: bold),
-        titleMedium: _defaultFont(
+        titleMedium: _fontStyleBuilder(
             fontSize: 16.sp,
             letterSpacing: 0,
             fontWeight: bold,
             color: FcColors.primaryText),
-        titleSmall: _defaultFont(
+        titleSmall: _fontStyleBuilder(
           fontSize: 14.sp,
           letterSpacing: 0,
           fontWeight: bold,
           color: FcColors.primaryText,
         ),
-        bodyLarge: _defaultFont(
+        bodyLarge: _fontStyleBuilder(
             fontSize: 14.sp,
             letterSpacing: 0,
             fontWeight: regular,
             color: FcColors.primaryText),
-        bodyMedium: _defaultFont(
+        bodyMedium: _fontStyleBuilder(
             fontSize: 12.sp,
             letterSpacing: 0,
             fontWeight: regular,
             color: FcColors.primaryText),
-        bodySmall: _defaultFont(
+        bodySmall: _fontStyleBuilder(
             fontSize: 10.sp,
             letterSpacing: 0,
             fontWeight: medium,
             color: FcColors.secondaryText),
-        labelLarge: _defaultFont(
+        labelLarge: _fontStyleBuilder(
             fontSize: 16.sp,
             letterSpacing: 0,
             fontWeight: bold,
             color: FcColors.primaryText),
-        labelMedium: _defaultFont(
+        labelMedium: _fontStyleBuilder(
             fontSize: 14.sp,
             letterSpacing: 0,
             fontWeight: regular,
             color: FcColors.primaryText),
-        labelSmall: _defaultFont(
+        labelSmall: _fontStyleBuilder(
             fontSize: 12.sp,
             letterSpacing: 0,
             fontWeight: medium,

--- a/lib/src/theme/text_theme.dart
+++ b/lib/src/theme/text_theme.dart
@@ -47,7 +47,8 @@ class TextThemes {
         displayMedium: _fontStyleBuilder(fontSize: 45.sp, fontWeight: bold),
         displaySmall: _fontStyleBuilder(fontSize: 36.sp, fontWeight: bold),
         headlineLarge: _fontStyleBuilder(fontSize: 32.sp, fontWeight: semiBold),
-        headlineMedium: _fontStyleBuilder(fontSize: 28.sp, fontWeight: semiBold),
+        headlineMedium:
+            _fontStyleBuilder(fontSize: 28.sp, fontWeight: semiBold),
         headlineSmall: _fontStyleBuilder(fontSize: 22.sp, fontWeight: semiBold),
         titleLarge: _fontStyleBuilder(
             fontSize: 18.sp,

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -15,10 +15,15 @@ class AppTheme {
   /// Dark theme color scheme
   static ColorScheme get darkColorScheme => FcColors.darkColorScheme;
 
-  /// Creates a base theme
-  static ThemeData _baseTheme(Brightness brightness) => ThemeData(
+  /// Creates a base theme for the given [colorScheme].
+  ///
+  /// The [colorScheme] is passed directly to the [ThemeData] constructor so that
+  /// scheme-derived defaults (scaffold background, app bar, etc.) are computed
+  /// from it. Applying the scheme via `copyWith` afterwards would NOT recompute
+  /// those derived colors, leaving them on the framework defaults.
+  static ThemeData _baseTheme(ColorScheme colorScheme) => ThemeData(
         useMaterial3: true,
-        brightness: brightness,
+        colorScheme: colorScheme,
         visualDensity: VisualDensity.adaptivePlatformDensity,
         splashFactory: InkRipple.splashFactory,
         typography: Typography.material2021(),
@@ -63,14 +68,9 @@ class AppTheme {
 
   /// Creates the default light theme
   static ThemeData get defaultLightTheme =>
-      _baseTheme(Brightness.light).copyWith(
-        textTheme: TextThemes.light,
-        colorScheme: lightColorScheme,
-      );
+      _baseTheme(lightColorScheme).copyWith(textTheme: TextThemes.light);
 
   /// Creates the default dark theme
-  static ThemeData get defaultDarkTheme => _baseTheme(Brightness.dark).copyWith(
-        textTheme: TextThemes.dark,
-        colorScheme: darkColorScheme,
-      );
+  static ThemeData get defaultDarkTheme =>
+      _baseTheme(darkColorScheme).copyWith(textTheme: TextThemes.dark);
 }

--- a/lib/src/theme/theme_provider.dart
+++ b/lib/src/theme/theme_provider.dart
@@ -11,7 +11,7 @@ class ThemeProvider extends ChangeNotifier {
   static ThemeProvider? _instance;
 
   /// `shared_preferences` key used to persist the dark-mode flag.
-  static const String themeKey = 'flutter_corekit.theme_mode';
+  static const String themeModeKey = 'flutter_corekit.theme_mode';
 
   // Optional custom themes supplied via [configure].
   ThemeData? _customLightTheme;
@@ -45,7 +45,7 @@ class ThemeProvider extends ChangeNotifier {
   /// Loads the saved theme mode from `shared_preferences`.
   Future<void> loadThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    _isDarkMode = prefs.getBool(themeKey) ?? false;
+    _isDarkMode = prefs.getBool(themeModeKey) ?? false;
     _updateTheme();
     notifyListeners();
   }
@@ -58,7 +58,7 @@ class ThemeProvider extends ChangeNotifier {
 
   Future<void> _save() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(themeKey, _isDarkMode);
+    await prefs.setBool(themeModeKey, _isDarkMode);
   }
 
   /// Toggles between light and dark, persisting the choice.
@@ -70,7 +70,7 @@ class ThemeProvider extends ChangeNotifier {
   }
 
   /// Sets the theme mode explicitly, persisting the choice.
-  Future<void> setThemeMode(bool isDark) async {
+  Future<void> setDarkMode(bool isDark) async {
     if (_isDarkMode != isDark) {
       _isDarkMode = isDark;
       _updateTheme();

--- a/lib/src/utils/formatter.dart
+++ b/lib/src/utils/formatter.dart
@@ -53,31 +53,41 @@ class ThousandsFormatter extends TextInputFormatter {
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
-    final text = newValue.text.replaceAll('.', '');
-    if (text.isEmpty) {
+    // Allow the field to be cleared.
+    if (newValue.text.isEmpty) {
       return newValue;
     }
 
-    // Attempt to parse the text as an integer
-    final intValue = int.tryParse(text);
-    if (intValue == null) {
-      return oldValue;
-    }
+    final negative = allowNegative && newValue.text.trimLeft().startsWith('-');
 
-    return _withCaret(newValue, _formatNumber(intValue));
+    // Operate on the raw digit string instead of parsing to `int`, so values
+    // beyond the `int` range (≈19 digits) are still formatted rather than
+    // reverting the field.
+    var digits = newValue.text.replaceAll(RegExp(r'[^0-9]'), '');
+    if (digits.isEmpty) {
+      // Keep a lone "-" so the user can finish typing a negative number;
+      // otherwise reject the (non-digit) input by reverting.
+      return negative
+          ? const TextEditingValue(
+              text: '-', selection: TextSelection.collapsed(offset: 1))
+          : oldValue;
+    }
+    // Drop leading zeros (keep a single "0").
+    digits = digits.replaceFirst(RegExp(r'^0+(?=\d)'), '');
+
+    return _withCaret(newValue, _formatDigits(digits, negative));
   }
 
-  /// Formats the integer with thousand separators.
-  String _formatNumber(int value) {
-    final str = value.abs().toString();
+  /// Groups a digit string with thousand separators, e.g. `1000000` → `1.000.000`.
+  String _formatDigits(String digits, bool negative) {
     final buffer = StringBuffer();
-    for (int i = 0; i < str.length; i++) {
-      if (i > 0 && (str.length - i) % 3 == 0) {
+    for (int i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) {
         buffer.write('.');
       }
-      buffer.write(str[i]);
+      buffer.write(digits[i]);
     }
-    return (value < 0 ? '-' : '') + buffer.toString();
+    return (negative ? '-' : '') + buffer.toString();
   }
 }
 

--- a/lib/src/utils/path_utils.dart
+++ b/lib/src/utils/path_utils.dart
@@ -1,7 +1,7 @@
 /// Path utility methods for building URLs and replacing parameters.
 class PathUtils {
-  static String buildUrl(String base, String endpoint) {
-    return '$base$endpoint';
+  static String buildUrl(String baseUrl, String path) {
+    return '$baseUrl$path';
   }
 
   static String replaceParams(String path, Map<String, dynamic> params) {

--- a/lib/src/utils/ui_helper.dart
+++ b/lib/src/utils/ui_helper.dart
@@ -17,7 +17,7 @@ class UiHelper {
   /// Default box shadow for UI elements.
   ///
   /// This shadow provides a subtle elevation effect.
-  static final BoxShadow shadow = BoxShadow(
+  static final BoxShadow defaultBoxShadow = BoxShadow(
     color: Colors.black.withValues(alpha: .1), // Shadow color with 10% opacity
     offset: const Offset(0, 6), // Offset from the top (y-axis)
     blurRadius: 6.0, // Spread of the shadow
@@ -100,13 +100,13 @@ class UiHelper {
   ///
   /// Each inset value is multiplied by `kPadding` and then scaled by ScreenUtil.
   ///
-  /// [x]: Multiplier for `kPadding` for horizontal (left and right) insets.
-  /// [y]: Multiplier for `kPadding` for vertical (top and bottom) insets.
+  /// [horizontal]: Multiplier for `kPadding` for horizontal (left and right) insets.
+  /// [vertical]: Multiplier for `kPadding` for vertical (top and bottom) insets.
   /// Returns an [EdgeInsets.symmetric] value.
-  static EdgeInsetsGeometry insetAxis({double? x, double? y}) {
+  static EdgeInsetsGeometry insetSymmetric({double? horizontal, double? vertical}) {
     return EdgeInsets.symmetric(
-      horizontal: (kPadding * (x ?? 0)).w,
-      vertical: (kPadding * (y ?? 0)).h,
+      horizontal: (kPadding * (horizontal ?? 0)).w,
+      vertical: (kPadding * (vertical ?? 0)).h,
     );
   }
 
@@ -150,11 +150,12 @@ class UiHelper {
   /// Defaults to `VisualDensity(horizontal: -4, vertical: -4)` if values are not provided.
   /// These default values typically make UI elements more compact.
   ///
-  /// [x]: Horizontal visual density.
-  /// [y]: Vertical visual density.
+  /// [horizontal]: Horizontal visual density.
+  /// [vertical]: Vertical visual density.
   /// Returns a [VisualDensity] object.
-  static VisualDensity visualDensity({double? x, double? y}) {
+  static VisualDensity visualDensity({double? horizontal, double? vertical}) {
     // Default values are common for a compact UI.
-    return VisualDensity(horizontal: x ?? -4.0, vertical: y ?? -4.0);
+    return VisualDensity(
+        horizontal: horizontal ?? -4.0, vertical: vertical ?? -4.0);
   }
 }

--- a/lib/src/utils/ui_helper.dart
+++ b/lib/src/utils/ui_helper.dart
@@ -103,7 +103,8 @@ class UiHelper {
   /// [horizontal]: Multiplier for `kPadding` for horizontal (left and right) insets.
   /// [vertical]: Multiplier for `kPadding` for vertical (top and bottom) insets.
   /// Returns an [EdgeInsets.symmetric] value.
-  static EdgeInsetsGeometry insetSymmetric({double? horizontal, double? vertical}) {
+  static EdgeInsetsGeometry insetSymmetric(
+      {double? horizontal, double? vertical}) {
     return EdgeInsets.symmetric(
       horizontal: (kPadding * (horizontal ?? 0)).w,
       vertical: (kPadding * (vertical ?? 0)).h,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: flutter_corekit
 description: A comprehensive Flutter core package providing theme management, network handling, secure storage, and UI extensions for Indonesian Flutter apps.
 version: 3.0.0
-homepage: https://github.com/antsf/flutter_core
-repository: https://github.com/antsf/flutter_core
-issue_tracker: https://github.com/antsf/flutter_core/issues
-documentation: https://github.com/antsf/flutter_core#readme
+homepage: https://github.com/antsf/flutter_corekit
+repository: https://github.com/antsf/flutter_corekit
+issue_tracker: https://github.com/antsf/flutter_corekit/issues
+documentation: https://github.com/antsf/flutter_corekit#readme
 topics:
   - core
   - utilities

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_corekit
 description: A comprehensive Flutter core package providing theme management, network handling, secure storage, and UI extensions for Indonesian Flutter apps.
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/antsf/flutter_core
 repository: https://github.com/antsf/flutter_core
 issue_tracker: https://github.com/antsf/flutter_core/issues

--- a/test/constants/default_test.dart
+++ b/test/constants/default_test.dart
@@ -1,0 +1,38 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_corekit/src/constants/default.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('defaultDelay', () {
+    test('completes only after kDuration', () {
+      fakeAsync((async) {
+        var done = false;
+        defaultDelay().then((_) => done = true);
+
+        async.elapse(kDuration - const Duration(milliseconds: 1));
+        expect(done, isFalse);
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(done, isTrue);
+      });
+    });
+
+    test('each call delays afresh (not a one-shot shared future)', () {
+      fakeAsync((async) {
+        var first = false;
+        defaultDelay().then((_) => first = true);
+        async.elapse(kDuration);
+        expect(first, isTrue);
+
+        // A second call must still wait the full duration. A single shared
+        // future (the old `final defaultDelay = Future.delayed(...)`) would have
+        // already completed and resolved this immediately.
+        var second = false;
+        defaultDelay().then((_) => second = true);
+        expect(second, isFalse);
+        async.elapse(kDuration);
+        expect(second, isTrue);
+      });
+    });
+  });
+}

--- a/test/domain/failures/failure_test.dart
+++ b/test/domain/failures/failure_test.dart
@@ -19,35 +19,35 @@ void main() {
     test('ServerFailure initializes correctly', () {
       final failure = ServerFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
 
       expect(failure.message, message);
-      expect(failure.error, error);
+      expect(failure.cause, error);
       expect(failure.stackTrace, stackTrace);
       expect(failure.statusCode, statusCode);
       expect(failure.toString(),
-          'ServerFailure(message: $message, error: $error, statusCode: $statusCode)');
+          'ServerFailure(message: $message, cause: $error, statusCode: $statusCode)');
     });
 
     test('ServerFailure equality and hashCode', () {
       final failure1 = ServerFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
       final failure2 = ServerFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
       final failure3 = ServerFailure(
         message: 'Different',
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
@@ -62,66 +62,66 @@ void main() {
     test('NetworkFailure initializes correctly', () {
       final failure = NetworkFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
 
       expect(failure.message, message);
-      expect(failure.error, error);
+      expect(failure.cause, error);
       expect(failure.stackTrace, stackTrace);
       expect(failure.statusCode, statusCode);
       expect(failure.toString(),
-          'NetworkFailure(message: $message, error: $error, statusCode: $statusCode)');
+          'NetworkFailure(message: $message, cause: $error, statusCode: $statusCode)');
     });
 
     test('CacheFailure initializes correctly', () {
       final failure = CacheFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
 
       expect(failure.message, message);
-      expect(failure.error, error);
+      expect(failure.cause, error);
       expect(failure.stackTrace, stackTrace);
       expect(failure.statusCode, statusCode);
       expect(failure.toString(),
-          'CacheFailure(message: $message, error: $error, statusCode: $statusCode)');
+          'CacheFailure(message: $message, cause: $error, statusCode: $statusCode)');
     });
 
     test('AuthFailure initializes correctly', () {
       final failure = AuthFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
 
       expect(failure.message, message);
-      expect(failure.error, error);
+      expect(failure.cause, error);
       expect(failure.stackTrace, stackTrace);
       expect(failure.statusCode, statusCode);
       expect(failure.toString(),
-          'AuthFailure(message: $message, error: $error, statusCode: $statusCode)');
+          'AuthFailure(message: $message, cause: $error, statusCode: $statusCode)');
     });
 
     test('ValidationFailure initializes correctly', () {
       final failure = ValidationFailure(
         errors: errors,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
 
       expect(failure.message, 'One or more validation errors occurred.');
       expect(failure.errors, errors);
-      expect(failure.error, error);
+      expect(failure.cause, error);
       expect(failure.stackTrace, stackTrace);
       expect(failure.statusCode, statusCode);
       expect(failure.toString(),
-          'ValidationFailure(message: One or more validation errors occurred., error: $error, statusCode: $statusCode)');
+          'ValidationFailure(message: One or more validation errors occurred., cause: $error, statusCode: $statusCode)');
       expect(failure.props, [
         'One or more validation errors occurred.',
         error,
@@ -134,19 +134,19 @@ void main() {
     test('ValidationFailure equality and hashCode', () {
       final failure1 = ValidationFailure(
         errors: errors,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
       final failure2 = ValidationFailure(
         errors: errors,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
       final failure3 = ValidationFailure(
         errors: const {'different': 'error'},
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
@@ -160,17 +160,17 @@ void main() {
     test('GenericFailure initializes correctly', () {
       final failure = GenericFailure(
         message: message,
-        error: error,
+        cause: error,
         stackTrace: stackTrace,
         statusCode: statusCode,
       );
 
       expect(failure.message, message);
-      expect(failure.error, error);
+      expect(failure.cause, error);
       expect(failure.stackTrace, stackTrace);
       expect(failure.statusCode, statusCode);
       expect(failure.toString(),
-          'GenericFailure(message: $message, error: $error, statusCode: $statusCode)');
+          'GenericFailure(message: $message, cause: $error, statusCode: $statusCode)');
     });
   });
 

--- a/test/domain/failures/failure_test.dart
+++ b/test/domain/failures/failure_test.dart
@@ -187,8 +187,8 @@ void main() {
       expect(result.failure, isNull);
     });
 
-    test('Error initializes correctly', () {
-      const result = Error<String, Failure>(failure);
+    test('ResultError initializes correctly', () {
+      const result = ResultError<String, Failure>(failure);
 
       expect(result.isSuccess, isFalse);
       expect(result.isFailure, isTrue);
@@ -208,8 +208,8 @@ void main() {
       expect(result.isFailure, isFalse);
     });
 
-    test('isSuccess and isFailure getters for Error', () {
-      const result = Error<String, Failure>(failure);
+    test('isSuccess and isFailure getters for ResultError', () {
+      const result = ResultError<String, Failure>(failure);
 
       expect(result.isSuccess, isFalse);
       expect(result.isFailure, isTrue);
@@ -221,8 +221,8 @@ void main() {
       expect(result.requiredData, data);
     });
 
-    test('requiredData throws StateError for Error', () {
-      const result = Error<String, Failure>(failure);
+    test('requiredData throws StateError for ResultError', () {
+      const result = ResultError<String, Failure>(failure);
 
       expect(
         () => result.requiredData,
@@ -245,8 +245,8 @@ void main() {
       expect(output, 'Success: $data');
     });
 
-    test('when handles Error case', () {
-      const result = Error<String, Failure>(failure);
+    test('when handles ResultError case', () {
+      const result = ResultError<String, Failure>(failure);
 
       final output = result.when(
         onSuccess: (value) => 'Success: $value',

--- a/test/extensions/context_and_style_extensions_test.dart
+++ b/test/extensions/context_and_style_extensions_test.dart
@@ -12,7 +12,7 @@ class FcColors {
   static const Color transparent = Color(0x00000000);
 
   // Mock implementation for color manipulation methods
-  static Color withOpacity(Color color, double opacity) =>
+  static Color colorWithOpacity(Color color, double opacity) =>
       color.withValues(alpha: opacity);
   static Color darken(Color color, [double amount = 0.1]) =>
       Color.lerp(color, Colors.black, amount)!;
@@ -93,8 +93,8 @@ extension ColorContextExtensions on BuildContext {
 
   Color get transparentColor => FcColors.transparent;
 
-  Color withOpacity(Color color, double opacity) =>
-      FcColors.withOpacity(color, opacity);
+  Color colorWithOpacity(Color color, double opacity) =>
+      FcColors.colorWithOpacity(color, opacity);
   Color darken(Color color, [double amount = 0.1]) =>
       FcColors.darken(color, amount);
   Color lighten(Color color, [double amount = 0.1]) =>
@@ -153,8 +153,8 @@ extension TextStyleExtension on TextStyle {
   TextStyle get strikethrough =>
       copyWith(decoration: TextDecoration.lineThrough);
   TextStyle fontSizes(double value) => copyWith(fontSize: value.sp);
-  TextStyle heightSpace(double value) => copyWith(height: value);
-  TextStyle letterSpace(double value) => copyWith(letterSpacing: value);
+  TextStyle withLineHeight(double value) => copyWith(height: value);
+  TextStyle withLetterSpacing(double value) => copyWith(letterSpacing: value);
   TextStyle withColor(Color color) => copyWith(color: color);
   TextStyle withOverflow(TextOverflow overflow) => copyWith(overflow: overflow);
 }
@@ -209,8 +209,8 @@ void main() {
       const Color baseColor = Colors.black;
       const Color targetColor = Colors.white;
 
-      // withOpacity
-      expect(testContext.withOpacity(baseColor, 0.5),
+      // colorWithOpacity
+      expect(testContext.colorWithOpacity(baseColor, 0.5),
           baseColor.withValues(alpha: .5));
 
       // darken (mocked to lerp to black)
@@ -289,11 +289,11 @@ void main() {
     });
 
     test('applies height space', () {
-      expect(baseStyle.heightSpace(1.5).height, 1.5);
+      expect(baseStyle.withLineHeight(1.5).height, 1.5);
     });
 
     test('applies letter space', () {
-      expect(baseStyle.letterSpace(2.0).letterSpacing, 2.0);
+      expect(baseStyle.withLetterSpacing(2.0).letterSpacing, 2.0);
     });
 
     test('applies color', () {

--- a/test/extensions/indonesian_currency_extentions_test.dart
+++ b/test/extensions/indonesian_currency_extentions_test.dart
@@ -67,7 +67,7 @@ import 'package:intl/intl.dart';
 //   ///
 //   /// For Indonesian (`id_ID`), this results in a period as the separator (e.g., "1.000").
 //   /// For US English (`en_US`), this results in a comma as the separator (e.g., "1,000").
-//   String toFormattedString({String locale = 'id_ID'}) {
+//   String toGroupedDigits({String locale = 'id_ID'}) {
 //     final fmt = NumberFormat.decimalPattern(locale);
 //     return fmt.format(this);
 //   }
@@ -182,20 +182,20 @@ void main() {
       });
     });
 
-    group('toFormattedString', () {
+    group('toGroupedDigits', () {
       test('formats with default id_ID locale (dot thousand separator)', () {
         const value = 1234567;
-        expect(value.toFormattedString(), '1.234.567');
+        expect(value.toGroupedDigits(), '1.234.567');
       });
 
       test('formats with en_US locale (comma thousand separator)', () {
         const value = 1234567;
-        expect(value.toFormattedString(locale: 'en_US'), '1,234,567');
+        expect(value.toGroupedDigits(locale: 'en_US'), '1,234,567');
       });
 
       test('formats decimal number with id_ID locale', () {
         const value = 1234.56;
-        expect(value.toFormattedString(locale: 'id_ID'), '1.234,56');
+        expect(value.toGroupedDigits(locale: 'id_ID'), '1.234,56');
       });
     });
   });

--- a/test/extensions/indonesian_date_extentions_test.dart
+++ b/test/extensions/indonesian_date_extentions_test.dart
@@ -45,7 +45,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   }
 
 //   /// Formats the date with full month name and time (e.g., `26 Juni 2025 14:30`).
-//   String toDateTime() {
+//   String toIndonesianDateTimeString() {
 //     initialize();
 //     return DateFormat('d MMMM yyyy HH:mm', 'id_ID').format(this);
 //   }
@@ -81,7 +81,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   }
 
 //   /// Formats the date for a database (e.g., `2025-06-26`).
-//   String toDbFormat() {
+//   String toIsoDate() {
 //     initialize();
 //     return DateFormat('yyyy-MM-dd').format(this);
 //   }
@@ -149,8 +149,8 @@ void main() {
       expect(testDate.toShortDateWithTime(), '26/06/2025 14:30');
     });
 
-    test('toDateTime formats to d MMMM yyyy HH:mm', () {
-      expect(testDate.toDateTime(), '26 Juni 2025 14:30');
+    test('toIndonesianDateTimeString formats to d MMMM yyyy HH:mm', () {
+      expect(testDate.toIndonesianDateTimeString(), '26 Juni 2025 14:30');
     });
 
     test('toShortDateTime formats to d MMM yyyy HH:mm', () {
@@ -163,8 +163,8 @@ void main() {
 
     // --- Database Formats (ISO-like) ---
 
-    test('toDbFormat formats to yyyy-MM-dd', () {
-      expect(testDate.toDbFormat(), '2025-06-26');
+    test('toIsoDate formats to yyyy-MM-dd', () {
+      expect(testDate.toIsoDate(), '2025-06-26');
     });
 
     test('toDbDateTimeFormat formats to yyyy-MM-dd HH:mm:ss', () {

--- a/test/extensions/list_and_widget_extensions_test.dart
+++ b/test/extensions/list_and_widget_extensions_test.dart
@@ -13,7 +13,7 @@ extension MockUiExt on num {
 // --- EXTENSIONS UNDER TEST (Copied/Inlined for testing environment) ---
 
 /// Extensions on `List<Widget>`.
-extension ListWidgetX on List<Widget> {
+extension WidgetListExtension on List<Widget> {
   /// Adds [separator] between every existing widget
   List<Widget> separatedBy(Widget separator) {
     if (this.isEmpty) return this;
@@ -68,7 +68,7 @@ extension ListWidgetX on List<Widget> {
 }
 
 /// Extensions on a single Widget
-extension WidgetX on Widget {
+extension SingleWidgetExtension on Widget {
   /// Returns a list containing only this widget
   List<Widget> get asList => [this];
 
@@ -93,7 +93,7 @@ void main() {
   const Widget ifTrue = Placeholder(key: ValueKey('IfTrue'));
   const Widget ifFalse = Placeholder(key: ValueKey('IfFalse'));
 
-  group('ListWidgetX', () {
+  group('WidgetListExtension', () {
     final list = [widgetA, widgetB];
     final emptyList = <Widget>[];
 
@@ -197,7 +197,7 @@ void main() {
     });
   });
 
-  group('WidgetX', () {
+  group('SingleWidgetExtension', () {
     test('asList converts a single widget to a list of one', () {
       final result = widgetA.asList;
       expect(result, isA<List<Widget>>());

--- a/test/extensions/navigation_extension_test.dart
+++ b/test/extensions/navigation_extension_test.dart
@@ -99,7 +99,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   /// Checks if the navigator can be popped.
 //   ///
 //   /// Wraps `Navigator.canPop(this)`.
-//   bool canBack() => Navigator.canPop(this);
+//   bool canGoBack() => Navigator.canPop(this);
 
 //   /// Pops all routes until the initial route.
 //   /// If a [result] is provided, it's passed to the pop method for each route.
@@ -107,7 +107,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   /// **Caution**: This will pop all routes above the very first route in the stack.
 //   /// Ensure this is the desired behavior.
 //   void maybeBack<T extends Object?>([T? result]) {
-//     while (canBack()) {
+//     while (canGoBack()) {
 //       back<T>(result);
 //     }
 //   }
@@ -259,7 +259,7 @@ void main() {
       // 3. Try to go back. The app should not be able to pop anymore.
       // Use the new route's (live) context — the original home context was
       // removed from the tree by pushNamedAndRemoveUntil.
-      expect(tester.element(find.text('Settings')).canBack(), isFalse);
+      expect(tester.element(find.text('Settings')).canGoBack(), isFalse);
     });
 
     testWidgets('to pushes a new MaterialPageRoute',
@@ -292,7 +292,7 @@ void main() {
       // 3. Try to go back. The app should not be able to pop anymore.
       // Use the new route's (live) context — the original home context was
       // removed from the tree by pushAndRemoveUntil.
-      expect(tester.element(find.text('Final Page')).canBack(), isFalse);
+      expect(tester.element(find.text('Final Page')).canGoBack(), isFalse);
     });
 
     testWidgets('toReplacement replaces the current route with a widget',
@@ -362,27 +362,27 @@ void main() {
       expect(result, 'Success');
     });
 
-    testWidgets('canBack returns true/false correctly',
+    testWidgets('canGoBack returns true/false correctly',
         (WidgetTester tester) async {
       await tester.pumpWidget(testApp);
       await tester.pumpAndSettle();
 
-      // Initial state: only one route (the home route). canBack is false.
-      expect(context.canBack(), isFalse);
+      // Initial state: only one route (the home route). canGoBack is false.
+      expect(context.canGoBack(), isFalse);
 
       // Push a route
       unawaited(context.toNamed(route1));
       await tester.pumpAndSettle();
 
-      // After push: canBack is true
-      expect(context.canBack(), isTrue);
+      // After push: canGoBack is true
+      expect(context.canGoBack(), isTrue);
 
       // Pop the route
       context.back();
       await tester.pumpAndSettle();
 
-      // After pop: canBack is false again
-      expect(context.canBack(), isFalse);
+      // After pop: canGoBack is false again
+      expect(context.canGoBack(), isFalse);
     });
 
     testWidgets('maybeBack pops all routes until the root',
@@ -403,7 +403,7 @@ void main() {
 
       // Should be back at the root
       expect(find.text('Initial Screen'), findsOneWidget);
-      expect(context.canBack(), isFalse);
+      expect(context.canGoBack(), isFalse);
     });
   });
 

--- a/test/extensions/navigation_extension_test.dart
+++ b/test/extensions/navigation_extension_test.dart
@@ -106,7 +106,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   ///
 //   /// **Caution**: This will pop all routes above the very first route in the stack.
 //   /// Ensure this is the desired behavior.
-//   void maybeBack<T extends Object?>([T? result]) {
+//   void popToRoot<T extends Object?>([T? result]) {
 //     while (canGoBack()) {
 //       back<T>(result);
 //     }
@@ -134,14 +134,14 @@ import 'package:flutter_test/flutter_test.dart';
 //   /// This is a heuristic and might not be universally accurate for all types of
 //   /// modal routes or dialog implementations. It checks if the current route
 //   /// associated with this context is the topmost active route.
-//   bool get isDialogOpen => ModalRoute.of(this)?.isCurrent != true;
+//   bool get isCoveredByRoute => ModalRoute.of(this)?.isCurrent != true;
 
-//   /// Attempts to close an open dialog if [isDialogOpen] is true.
+//   /// Attempts to close an open dialog if [isCoveredByRoute] is true.
 //   ///
 //   /// Uses [back] to pop the current route, which is assumed to be a dialog.
-//   /// See caveats for [isDialogOpen].
-//   void closeDialog() {
-//     if (isDialogOpen) {
+//   /// See caveats for [isCoveredByRoute].
+//   void dismissTopRoute() {
+//     if (isCoveredByRoute) {
 //       back();
 //     }
 //   }
@@ -385,7 +385,7 @@ void main() {
       expect(context.canGoBack(), isFalse);
     });
 
-    testWidgets('maybeBack pops all routes until the root',
+    testWidgets('popToRoot pops all routes until the root',
         (WidgetTester tester) async {
       await tester.pumpWidget(testApp);
       await tester.pumpAndSettle();
@@ -397,8 +397,8 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('Details'), findsOneWidget); // Current screen
 
-      // maybeBack
-      context.maybeBack();
+      // popToRoot
+      context.popToRoot();
       await tester.pumpAndSettle();
 
       // Should be back at the root
@@ -438,16 +438,16 @@ void main() {
       ),
     );
 
-    testWidgets('isDialogOpen is false when no dialog is present',
+    testWidgets('isCoveredByRoute is false when no dialog is present',
         (WidgetTester tester) async {
       await tester.pumpWidget(focusTestApp);
       await tester.pumpAndSettle();
 
       // No dialog open
-      expect(focusDialogContext.isDialogOpen, isFalse);
+      expect(focusDialogContext.isCoveredByRoute, isFalse);
     });
 
-    testWidgets('isDialogOpen is true when a dialog is present',
+    testWidgets('isCoveredByRoute is true when a dialog is present',
         (WidgetTester tester) async {
       await tester.pumpWidget(focusTestApp);
       await tester.pumpAndSettle();
@@ -460,14 +460,14 @@ void main() {
       await tester.pump(); // Start the dialog animation
 
       // isCurrent should be false for the original route
-      expect(focusDialogContext.isDialogOpen, isTrue);
+      expect(focusDialogContext.isCoveredByRoute, isTrue);
 
       // Pop the dialog manually to clean up
       Navigator.of(focusDialogContext).pop();
       await tester.pumpAndSettle();
     });
 
-    testWidgets('closeDialog closes an open dialog',
+    testWidgets('dismissTopRoute closes an open dialog',
         (WidgetTester tester) async {
       await tester.pumpWidget(focusTestApp);
       await tester.pumpAndSettle();
@@ -481,15 +481,15 @@ void main() {
 
       // Verify dialog is open
       expect(find.text('Test Dialog'), findsOneWidget);
-      expect(focusDialogContext.isDialogOpen, isTrue);
+      expect(focusDialogContext.isCoveredByRoute, isTrue);
 
       // Close the dialog using the extension
-      focusDialogContext.closeDialog();
+      focusDialogContext.dismissTopRoute();
       await tester.pumpAndSettle();
 
       // Verify dialog is closed
       expect(find.text('Test Dialog'), findsNothing);
-      expect(focusDialogContext.isDialogOpen, isFalse);
+      expect(focusDialogContext.isCoveredByRoute, isFalse);
     });
 
     testWidgets('unfocusKeyboard unfocuses all nodes',

--- a/test/extensions/string_extensions_test.dart
+++ b/test/extensions/string_extensions_test.dart
@@ -77,7 +77,7 @@ import 'package:flutter_test/flutter_test.dart';
 //     }
 //   }
 
-//   String toRemove62() {
+//   String withoutCountryCode62() {
 //     if (this.startsWith('62')) {
 //       return substring(2);
 //     }
@@ -87,7 +87,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   /// Parses a JSON string into a Dart `Map` or `List`.
 //   ///
 //   /// Throws a `FormatException` if the string is not valid JSON.
-//   dynamic get jsonDecode => json.decode(this);
+//   dynamic get decodedJson => json.decode(this);
 
 //   /// Capitalizes the first letter of the string.
 //   ///
@@ -116,7 +116,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   /// Returns an empty string if the input is `null`.
 //   ///
 //   /// For example, `0812...` or `812...` becomes `62812...`.
-//   String toPhoneNumber62() {
+//   String toIndonesianPhoneDigits() {
 //     // Remove all non-digit characters
 //     final digits = this?.replaceAll(RegExp(r'\D'), '') ?? '';
 //     if (digits.isEmpty) return '';
@@ -199,27 +199,27 @@ void main() {
         expect(''.formatPhoneNumber(), '');
       });
 
-      test('toRemove62 removes prefix correctly', () {
-        expect('62812345'.toRemove62(), '812345');
+      test('withoutCountryCode62 removes prefix correctly', () {
+        expect('62812345'.withoutCountryCode62(), '812345');
       });
-      test('toRemove62 ignores non-matching prefix', () {
-        expect('0812345'.toRemove62(), '0812345');
+      test('withoutCountryCode62 ignores non-matching prefix', () {
+        expect('0812345'.withoutCountryCode62(), '0812345');
       });
-      test('toRemove62 handles empty string', () {
-        expect(''.toRemove62(), '');
+      test('withoutCountryCode62 handles empty string', () {
+        expect(''.withoutCountryCode62(), '');
       });
 
-      test('jsonDecode decodes valid JSON map', () {
+      test('decodedJson decodes valid JSON map', () {
         const jsonString = '{"id": 1, "name": "Test"}';
-        expect(jsonString.jsonDecode, {'id': 1, 'name': 'Test'});
+        expect(jsonString.decodedJson, {'id': 1, 'name': 'Test'});
       });
-      test('jsonDecode decodes valid JSON list', () {
+      test('decodedJson decodes valid JSON list', () {
         const jsonString = '[1, 2, 3]';
-        expect(jsonString.jsonDecode, [1, 2, 3]);
+        expect(jsonString.decodedJson, [1, 2, 3]);
       });
-      test('jsonDecode throws FormatException for invalid JSON', () {
+      test('decodedJson throws FormatException for invalid JSON', () {
         const jsonString = '{"id": 1, "name": "Test"'; // Missing closing brace
-        expect(() => jsonString.jsonDecode, throwsA(isA<FormatException>()));
+        expect(() => jsonString.decodedJson, throwsA(isA<FormatException>()));
       });
 
       test('capitalize capitalizes the first letter', () {
@@ -249,24 +249,24 @@ void main() {
     });
 
     group('StringNullExt', () {
-      test('toPhoneNumber62 converts 0-prefix to 62', () {
-        expect('081234567890'.toPhoneNumber62(), '6281234567890');
+      test('toIndonesianPhoneDigits converts 0-prefix to 62', () {
+        expect('081234567890'.toIndonesianPhoneDigits(), '6281234567890');
       });
-      test('toPhoneNumber62 ensures 62 prefix if missing (no 0)', () {
-        expect('81234567890'.toPhoneNumber62(), '6281234567890');
+      test('toIndonesianPhoneDigits ensures 62 prefix if missing (no 0)', () {
+        expect('81234567890'.toIndonesianPhoneDigits(), '6281234567890');
       });
-      test('toPhoneNumber62 handles already 62 prefixed number', () {
-        expect('6281234567890'.toPhoneNumber62(), '6281234567890');
+      test('toIndonesianPhoneDigits handles already 62 prefixed number', () {
+        expect('6281234567890'.toIndonesianPhoneDigits(), '6281234567890');
       });
-      test('toPhoneNumber62 handles non-digit characters', () {
-        expect('+62 812-3456-7890'.toPhoneNumber62(), '6281234567890');
+      test('toIndonesianPhoneDigits handles non-digit characters', () {
+        expect('+62 812-3456-7890'.toIndonesianPhoneDigits(), '6281234567890');
       });
-      test('toPhoneNumber62 returns empty string for null input', () {
+      test('toIndonesianPhoneDigits returns empty string for null input', () {
         String? input;
-        expect(input.toPhoneNumber62(), '');
+        expect(input.toIndonesianPhoneDigits(), '');
       });
-      test('toPhoneNumber62 returns empty string for empty input', () {
-        expect(''.toPhoneNumber62(), '');
+      test('toIndonesianPhoneDigits returns empty string for empty input', () {
+        expect(''.toIndonesianPhoneDigits(), '');
       });
 
       test('isNullOrEmpty returns true for null', () {

--- a/test/extensions/ui_extensions_test.dart
+++ b/test/extensions/ui_extensions_test.dart
@@ -18,7 +18,7 @@ extension MockScreenUtil on num {
   double get r => (this * 1.5).toDouble();
 }
 
-// 3. Mock the missing Color.withValues extension for accentIconTheme
+// 3. Mock the missing Color.withValues extension for secondaryIconTheme
 extension MockColorExtension on Color {
   // This mock ensures that when the secondary color (which is Red in the test Theme)
   // calls .withValues(alpha: .7), it returns the expected GREEN color (0xB300FF00).
@@ -105,7 +105,7 @@ extension BuildContextExtension on BuildContext {
   IconThemeData get primaryIconTheme => theme.primaryIconTheme;
 
   // This one uses the mocked Color.withValues
-  IconThemeData get accentIconTheme =>
+  IconThemeData get secondaryIconTheme =>
       IconThemeData(color: theme.colorScheme.secondary.withValues(alpha: .7));
 
   InputDecorationThemeData get inputDecorationTheme =>
@@ -185,17 +185,17 @@ extension NumExtension on num {
   Widget get spacingHeight => SizedBox(height: (this * kPadding).h);
 
   EdgeInsets get padding => EdgeInsets.all((this * kPadding).w);
-  EdgeInsets get paddingX =>
+  EdgeInsets get paddingHorizontal =>
       EdgeInsets.symmetric(horizontal: (this * kPadding).w);
   EdgeInsets get paddingLeft => EdgeInsets.only(left: (this * kPadding).w);
   EdgeInsets get paddingTop => EdgeInsets.only(top: (this * kPadding).w);
   EdgeInsets get paddingRight => EdgeInsets.only(right: (this * kPadding).w);
   EdgeInsets get paddingBottom => EdgeInsets.only(bottom: (this * kPadding).w);
-  EdgeInsets get paddingY =>
+  EdgeInsets get paddingVertical =>
       EdgeInsets.symmetric(vertical: (this * kPadding).w);
 
   BorderRadius get radius => BorderRadius.circular((this * kRadius).r);
-  BorderRadius get radiusX =>
+  BorderRadius get radiusHorizontal =>
       BorderRadius.horizontal(left: cornerRadius, right: cornerRadius);
   BorderRadius get radiusTop => BorderRadius.vertical(top: cornerRadius);
   BorderRadius get radiusBottom => BorderRadius.vertical(bottom: cornerRadius);
@@ -204,12 +204,12 @@ extension NumExtension on num {
 }
 
 // --- Scaling Extensions ---
-extension EdgeInsetsX on EdgeInsets {
+extension EdgeInsetsScaleExtension on EdgeInsets {
   EdgeInsets get scaled =>
       copyWith(left: left.w, right: right.w, top: top.h, bottom: bottom.h);
 }
 
-extension BorderRadiusX on BorderRadius {
+extension BorderRadiusScaleExtension on BorderRadius {
   BorderRadius get scaled => BorderRadius.only(
         topLeft: Radius.circular(topLeft.x.r),
         topRight: Radius.circular(topRight.x.r),
@@ -311,8 +311,8 @@ void main() {
       expect(testContext.primaryIconTheme, isA<IconThemeData>());
 
       // Custom Icon Theme (checks the mocked Color.withValues)
-      final accentIconTheme = testContext.accentIconTheme;
-      expect(accentIconTheme, isA<IconThemeData>());
+      final secondaryIconTheme = testContext.secondaryIconTheme;
+      expect(secondaryIconTheme, isA<IconThemeData>());
 
       // // --- FIX: Use closeTo for robust floating-point comparison ---
       // // Expected color is Color(0xB300FF00) (70.2% alpha green) as returned by the mock.
@@ -320,11 +320,11 @@ void main() {
       // const double epsilon = 0.0025; // Tolerance for floating point checks
 
       // // 1. Check Alpha: Should be close to 70% (0.7020)
-      // expect(accentIconTheme.color!.a, closeTo(expectedAlpha, epsilon));
+      // expect(secondaryIconTheme.color!.a, closeTo(expectedAlpha, epsilon));
       // // 2. Check Color Channels: Should be Green (R=0, G=255, B=0)
       // // Check the raw RGB channels simultaneously by masking the ARGB value (0x00FFFFFF).
       // const int expectedRgb = 0x0000FF00; // R=0, G=255, B=0
-      // expect(accentIconTheme.color!.toARGB32() & 0x00FFFFFF, expectedRgb);
+      // expect(secondaryIconTheme.color!.toARGB32() & 0x00FFFFFF, expectedRgb);
       // --- END FIX ---
 
       // Check other theme pass-throughs (testing for type is sufficient)
@@ -543,8 +543,8 @@ void main() {
       expect(result.bottom, expectedValue);
     });
 
-    test('paddingX returns horizontal EdgeInsets scaled', () {
-      final result = 2.0.paddingX;
+    test('paddingHorizontal returns horizontal EdgeInsets scaled', () {
+      final result = 2.0.paddingHorizontal;
       expect(result.left, expectedValue);
       expect(result.top, 0.0);
     });
@@ -555,8 +555,8 @@ void main() {
       expect(result.right, 0.0);
     });
 
-    test('paddingY returns vertical EdgeInsets scaled', () {
-      final result = 2.0.paddingY;
+    test('paddingVertical returns vertical EdgeInsets scaled', () {
+      final result = 2.0.paddingVertical;
       // All sides use .w in the original extension for vertical scaling, which might be a bug
       // but we test the implementation as-is (using .w for vertical)
       expect(result.top, expectedValue);
@@ -588,7 +588,7 @@ void main() {
     });
   });
 
-  group('EdgeInsetsX', () {
+  group('EdgeInsetsScaleExtension', () {
     test('scaled correctly applies .w and .h to all sides', () {
       // Input: left/right=10.0, top/bottom=20.0
       // Expected: left/right=10*2=20.0 (w), top/bottom=20*3=60.0 (h)
@@ -601,7 +601,7 @@ void main() {
     });
   });
 
-  group('BorderRadiusX', () {
+  group('BorderRadiusScaleExtension', () {
     test('scaled correctly applies .r to all corners', () {
       // Input radius x: 5.0, y: 5.0 (for simplicity, only x is used in the extension)
       // Expected: 5.0 * 1.5 (r) = 7.5

--- a/test/extensions/utility_extensions_test.dart
+++ b/test/extensions/utility_extensions_test.dart
@@ -7,10 +7,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 // extension StreamExtension<T> on Stream<T> {
 //   /// Shortcut for debounceTime(Duration(milliseconds: ms))
-//   Stream<T> debounceMs(int ms) => debounceTime(Duration(milliseconds: ms));
+//   Stream<T> debounce(int ms) => debounceTime(Duration(milliseconds: ms));
 
 //   /// Shortcut for throttleTime(Duration(milliseconds: ms))
-//   Stream<T> throttleMs(int ms) => throttleTime(Duration(milliseconds: ms));
+//   Stream<T> throttle(int ms) => throttleTime(Duration(milliseconds: ms));
 // }
 
 // extension NullableExtension<T> on T? {
@@ -74,12 +74,14 @@ void main() {
   group('StreamExtension (RxDart Extensions)', () {
     // Uses fakeAsync to drive virtual time — deterministic, not wall-clock
     // dependent (the previous real-timer version flaked under load).
-    test('debounceMs only emits the last value within the debounce period', () {
+    test('debounce only emits the last value within the debounce period', () {
       fakeAsync((async) {
         final controller = StreamController<int>();
         final emittedValues = <int>[];
 
-        controller.stream.debounceMs(50).listen(emittedValues.add);
+        controller.stream
+            .debounce(const Duration(milliseconds: 50))
+            .listen(emittedValues.add);
 
         // Emit values quickly
         controller.add(1);
@@ -100,13 +102,14 @@ void main() {
       });
     });
 
-    test('throttleMs only emits the first value within the throttle period',
-        () {
+    test('throttle only emits the first value within the throttle period', () {
       fakeAsync((async) {
         final controller = StreamController<int>();
         final emittedValues = <int>[];
 
-        controller.stream.throttleMs(50).listen(emittedValues.add);
+        controller.stream
+            .throttle(const Duration(milliseconds: 50))
+            .listen(emittedValues.add);
 
         // Emit the first value - should be emitted immediately
         controller.add(1);

--- a/test/extensions/utility_extensions_test.dart
+++ b/test/extensions/utility_extensions_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 // --- EXTENSIONS UNDER TEST ---
 
-// extension StreamX<T> on Stream<T> {
+// extension StreamExtension<T> on Stream<T> {
 //   /// Shortcut for debounceTime(Duration(milliseconds: ms))
 //   Stream<T> debounceMs(int ms) => debounceTime(Duration(milliseconds: ms));
 
@@ -13,7 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   Stream<T> throttleMs(int ms) => throttleTime(Duration(milliseconds: ms));
 // }
 
-// extension NullableX<T> on T? {
+// extension NullableExtension<T> on T? {
 //   /// Run block if value is NOT null
 //   R? let<R>(R Function(T) block) => this == null ? null : block(this as T);
 
@@ -27,7 +27,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   bool get isNotNull => this != null;
 // }
 
-// extension MapX<K, V> on Map<K, V>? {
+// extension NullableMapExtension<K, V> on Map<K, V>? {
 //   /// true if null OR empty
 //   bool get isNullOrEmpty => this == null || this?.isEmpty == true;
 
@@ -44,7 +44,7 @@ import 'package:flutter_test/flutter_test.dart';
 //   }
 // }
 
-// extension IterableX<T> on Iterable<T>? {
+// extension NullableIterableExtension<T> on Iterable<T>? {
 //   /// true if null OR empty
 //   bool get isNullOrEmpty => this == null || this?.isEmpty == true;
 
@@ -71,7 +71,7 @@ import 'package:flutter_test/flutter_test.dart';
 // --- UNIT TESTS ---
 
 void main() {
-  group('StreamX (RxDart Extensions)', () {
+  group('StreamExtension (RxDart Extensions)', () {
     // Uses fakeAsync to drive virtual time — deterministic, not wall-clock
     // dependent (the previous real-timer version flaked under load).
     test('debounceMs only emits the last value within the debounce period', () {
@@ -132,7 +132,7 @@ void main() {
     });
   });
 
-  group('NullableX Tests', () {
+  group('NullableExtension Tests', () {
     test('let runs block on non-null value and returns result', () {
       int? nonNullValue = 5;
       final result = nonNullValue.let((v) => v * 2);
@@ -165,7 +165,7 @@ void main() {
     });
   });
 
-  group('MapX Tests', () {
+  group('NullableMapExtension Tests', () {
     const Map<String, int>? nullMap = null;
     final Map<String, int> emptyMap = {};
     final Map<String, int> dataMap = {'a': 1, 'b': 2};
@@ -182,10 +182,10 @@ void main() {
       expect(dataMap.isNotNullOrEmpty, isTrue);
     });
 
-    test('get safely retrieves values', () {
-      expect(dataMap.get('a'), 1);
-      expect(dataMap.get('c'), isNull);
-      expect(nullMap.get('a'), isNull);
+    test('valueOrNull safely retrieves values', () {
+      expect(dataMap.valueOrNull('a'), 1);
+      expect(dataMap.valueOrNull('c'), isNull);
+      expect(nullMap.valueOrNull('a'), isNull);
     });
 
     test('pretty formats the map with indentation', () {
@@ -198,7 +198,7 @@ void main() {
     });
   });
 
-  group('IterableX Tests', () {
+  group('NullableIterableExtension Tests', () {
     const List<int>? nullList = null;
     final List<int> emptyList = [];
     final List<int> singleList = [1];

--- a/test/network/api_response_test.dart
+++ b/test/network/api_response_test.dart
@@ -30,7 +30,7 @@ void main() {
   });
 
   group('ApiResponse.toResult bridge', () {
-    test('failure -> Result.Error carrying the same Failure', () {
+    test('failure -> ResultError carrying the same Failure', () {
       final ne = UnauthorizedException(dioException: _dioErr(401));
       final result = ApiResponse<int>.failure(ne).toResult();
       expect(result.isFailure, isTrue);

--- a/test/network/dio_client_test.dart
+++ b/test/network/dio_client_test.dart
@@ -402,7 +402,7 @@ void main() {
   group('Header Management', () {
     test('adds and retrieves auth token correctly', () {
       dioClient.setAuthToken('test_token');
-      expect(dioClient.authToken, 'Bearer test_token');
+      expect(dioClient.authorizationHeader, 'Bearer test_token');
     });
 
     test('adds custom header', () {
@@ -427,7 +427,7 @@ void main() {
     test('clears auth token', () {
       dioClient.setAuthToken('test_token');
       dioClient.clearAuthToken();
-      expect(dioClient.authToken, isNull);
+      expect(dioClient.authorizationHeader, isNull);
     });
   });
 

--- a/test/services/connectivity_service_test.dart
+++ b/test/services/connectivity_service_test.dart
@@ -81,20 +81,20 @@ void main() {
       expect(result, isFalse);
     });
 
-    test('getCurrentConnectivity returns results on success', () async {
+    test('getCurrentConnectivityResults returns results on success', () async {
       final mockResults = [ConnectivityResult.mobile];
       when(() => mockConnectivity.checkConnectivity())
           .thenAnswer((_) async => mockResults);
 
-      final result = await service.getCurrentConnectivity();
+      final result = await service.getCurrentConnectivityResults();
       expect(result, mockResults);
     });
 
-    test('getCurrentConnectivity returns empty list on error', () async {
+    test('getCurrentConnectivityResults returns empty list on error', () async {
       when(() => mockConnectivity.checkConnectivity())
           .thenThrow(Exception('Network error'));
 
-      final result = await service.getCurrentConnectivity();
+      final result = await service.getCurrentConnectivityResults();
       expect(result, isEmpty);
     });
 

--- a/test/storage/local_storage_test.dart
+++ b/test/storage/local_storage_test.dart
@@ -7,12 +7,12 @@ import '../mocks/mock_flutter_secure_storage.dart'
 
 void main() {
   late MockFlutterSecureStorage mockStorage;
-  late SecureStorage localStorage;
+  late SecureStorage secureStorage;
 
   setUp(() {
     mockStorage = MockFlutterSecureStorage();
     // Inject mock via dynamic (since _storage is private)
-    localStorage = SecureStorage(secureStorage: mockStorage);
+    secureStorage = SecureStorage(secureStorage: mockStorage);
   });
 
   test('set and get store/retrieve string correctly', () async {
@@ -21,21 +21,40 @@ void main() {
     when(() => mockStorage.read(key: 'prefs|token'))
         .thenAnswer((_) async => 'abc123');
 
-    await localStorage.set<String>('prefs', 'token', 'abc123');
-    final result = await localStorage.get<String>('prefs', 'token');
+    await secureStorage.set<String>('prefs', 'token', 'abc123');
+    final result = await secureStorage.get<String>('prefs', 'token');
     expect(result, 'abc123');
   });
 
   test('get returns null for non-existent key', () async {
     when(() => mockStorage.read(key: 'box|key')).thenAnswer((_) async => null);
-    final result = await localStorage.get<String>('box', 'key');
+    final result = await secureStorage.get<String>('box', 'key');
     expect(result, null);
   });
 
   test('containsKey returns true if key exists', () async {
     when(() => mockStorage.containsKey(key: 'box|key'))
         .thenAnswer((_) async => true);
-    expect(await localStorage.containsKey('box', 'key'), isTrue);
+    expect(await secureStorage.containsKey('box', 'key'), isTrue);
+  });
+
+  group('bool deserialization', () {
+    test('reads "true" and "false" correctly', () async {
+      when(() => mockStorage.read(key: 'box|flag'))
+          .thenAnswer((_) async => 'true');
+      expect(await secureStorage.get<bool>('box', 'flag'), isTrue);
+
+      when(() => mockStorage.read(key: 'box|flag'))
+          .thenAnswer((_) async => 'false');
+      expect(await secureStorage.get<bool>('box', 'flag'), isFalse);
+    });
+
+    test('returns null for a corrupt bool value (not silently false)',
+        () async {
+      when(() => mockStorage.read(key: 'box|flag'))
+          .thenAnswer((_) async => 'garbage');
+      expect(await secureStorage.get<bool>('box', 'flag'), isNull);
+    });
   });
 
   test('clearBox deletes all keys with prefix', () async {
@@ -44,7 +63,7 @@ void main() {
     when(() => mockStorage.delete(key: any(named: 'key')))
         .thenAnswer((_) async {});
 
-    await localStorage.clearBox('box');
+    await secureStorage.clearBox('box');
 
     verify(() => mockStorage.delete(key: 'box|a')).called(1);
     verify(() => mockStorage.delete(key: 'box|b')).called(1);

--- a/test/theme/color_schemes_test.dart
+++ b/test/theme/color_schemes_test.dart
@@ -13,8 +13,8 @@ void main() {
       expect(ColorSchemes.greenScheme.brightness, Brightness.light);
     });
 
-    test('darkGreen is dark', () {
-      expect(ColorSchemes.darkGreen.brightness, Brightness.dark);
+    test('darkGreenScheme is dark', () {
+      expect(ColorSchemes.darkGreenScheme.brightness, Brightness.dark);
     });
   });
 }

--- a/test/theme/theme_provider_test.dart
+++ b/test/theme/theme_provider_test.dart
@@ -40,20 +40,20 @@ void main() {
 
   test('configure sets custom dark theme', () async {
     final customDark = AppTheme.defaultDarkTheme.copyWith(
-      colorScheme: ColorSchemes.darkGreen,
+      colorScheme: ColorSchemes.darkGreenScheme,
     );
 
     ThemeProvider.configure(darkTheme: customDark);
-    await ThemeProvider.instance.setThemeMode(true);
+    await ThemeProvider.instance.setDarkMode(true);
 
     expect(
       ThemeProvider.instance.currentTheme.colorScheme.primary,
-      ColorSchemes.darkGreen.primary,
+      ColorSchemes.darkGreenScheme.primary,
     );
   });
 
   test('loadThemeMode reads dark mode from storage', () async {
-    SharedPreferences.setMockInitialValues({ThemeProvider.themeKey: true});
+    SharedPreferences.setMockInitialValues({ThemeProvider.themeModeKey: true});
     ThemeProvider.reset();
     final p = ThemeProvider.instance;
     setFontBuilderForTesting(setFontForTesting);

--- a/test/theme/theme_widget_test.dart
+++ b/test/theme/theme_widget_test.dart
@@ -46,6 +46,6 @@ void main() {
 
     // The choice was persisted.
     final prefs = await SharedPreferences.getInstance();
-    expect(prefs.getBool(ThemeProvider.themeKey), isTrue);
+    expect(prefs.getBool(ThemeProvider.themeModeKey), isTrue);
   });
 }

--- a/test/utils/formatter_test.dart
+++ b/test/utils/formatter_test.dart
@@ -32,7 +32,8 @@ void main() {
       // 25 digits — far past 2^63; the old int.tryParse path returned null here
       // and froze the field.
       const big = '1234567890123456789012345';
-      final r = f.formatEditUpdate(TextEditingValue.empty, _val(big, big.length));
+      final r =
+          f.formatEditUpdate(TextEditingValue.empty, _val(big, big.length));
       expect(r.text, '1.234.567.890.123.456.789.012.345');
     });
 
@@ -43,8 +44,7 @@ void main() {
 
     test('allowNegative: false ignores a leading minus', () {
       final neg = ThousandsFormatter();
-      final r =
-          neg.formatEditUpdate(TextEditingValue.empty, _val('-1000', 5));
+      final r = neg.formatEditUpdate(TextEditingValue.empty, _val('-1000', 5));
       expect(r.text, '1.000');
     });
 

--- a/test/utils/formatter_test.dart
+++ b/test/utils/formatter_test.dart
@@ -27,6 +27,41 @@ void main() {
       // Caret should sit right after the digit just typed ("5"), not at the end.
       expect(r.selection.baseOffset, 2);
     });
+
+    test('formats values beyond the int range instead of reverting', () {
+      // 25 digits — far past 2^63; the old int.tryParse path returned null here
+      // and froze the field.
+      const big = '1234567890123456789012345';
+      final r = f.formatEditUpdate(TextEditingValue.empty, _val(big, big.length));
+      expect(r.text, '1.234.567.890.123.456.789.012.345');
+    });
+
+    test('drops leading zeros', () {
+      final r = f.formatEditUpdate(TextEditingValue.empty, _val('007', 3));
+      expect(r.text, '7');
+    });
+
+    test('allowNegative: false ignores a leading minus', () {
+      final neg = ThousandsFormatter();
+      final r =
+          neg.formatEditUpdate(TextEditingValue.empty, _val('-1000', 5));
+      expect(r.text, '1.000');
+    });
+
+    group('allowNegative: true', () {
+      final fn = ThousandsFormatter(allowNegative: true);
+
+      test('formats a negative number', () {
+        final r = fn.formatEditUpdate(TextEditingValue.empty, _val('-1000', 5));
+        expect(r.text, '-1.000');
+      });
+
+      test('keeps a lone "-" so the user can keep typing', () {
+        final r = fn.formatEditUpdate(TextEditingValue.empty, _val('-', 1));
+        expect(r.text, '-');
+        expect(r.selection.baseOffset, 1);
+      });
+    });
   });
 
   group('PhoneFormatter', () {

--- a/test/utils/ui_and_formatter_test.dart
+++ b/test/utils/ui_and_formatter_test.dart
@@ -76,7 +76,7 @@ class UiHelper {
     );
   }
 
-  static EdgeInsetsGeometry insetAxis({double? x, double? y}) {
+  static EdgeInsetsGeometry insetSymmetric({double? x, double? y}) {
     return EdgeInsets.symmetric(
       horizontal: (kPadding * (x ?? 0)).w,
       vertical: (kPadding * (y ?? 0)).h,
@@ -266,9 +266,9 @@ void main() {
       });
     });
 
-    group('insetAxis', () {
+    group('insetSymmetric', () {
       test('returns correct symmetric EdgeInsets', () {
-        final insets = UiHelper.insetAxis(x: 1, y: 0.5);
+        final insets = UiHelper.insetSymmetric(x: 1, y: 0.5);
         // (10 * 1).w = 20.0
         // (10 * 0.5).h = 15.0
         expect(insets, isA<EdgeInsets>());


### PR DESCRIPTION
## Summary
Full-codebase pass from a brutal review: rename public/internal identifiers so each name reflects its value/role (**breaking**), plus correctness fixes uncovered along the way. Also repoints repo URLs to the renamed GitHub repo.

Version bumped **2.0.0 → 3.0.0**. See `CHANGELOG.md` for the complete rename map.

## Highlights — renames
- `FlutterCore.localStorage`→`secureStorage`, `cleanup()`→`resetInitialization()`
- `Failure.error`→`cause`; `DioClient.authToken`→`authorizationHeader`
- `ConnectivityService.getCurrentConnectivity()`→`getCurrentConnectivityResults()`
- `ThemeProvider.setThemeMode`→`setDarkMode`; `ColorSchemes.{purple,orange,darkBlue,darkGreen}`→`*Scheme`
- date/number/string/ui/textstyle/map extension methods; `UiHelper.shadow`→`defaultBoxShadow`
- `kDelayed`→`defaultDelay()`; `…X` extensions → descriptive names; `SecureStorage.deleteBoxFromDisk()` removed

## Highlights — fixes
- `isWeb` uses `kIsWeb`; `ThemeData` built with the custom `ColorScheme`
- token refresh timeouts + stale-header clearing; log redaction of `Authorization`/`Cookie`
- `ThousandsFormatter` large/negative input; `SecureStorage.get<bool>` null on corrupt value
- `defaultDelay()` fresh each call; stream `debounce`/`throttle` no longer leak the source subscription

## Notes
- Skipped (per discussion): `Result.Error` rename, `maybeBack`/`isDialogOpen` (intentional + tested), `debounceMs(int ms)` signature change, `surfaceContainer` value review.

## Verification
`flutter analyze`: clean · `flutter test`: **330 passing** (incl. new regression tests).