### PR TITLE
refactor!: rename FlutterCore -> FlutterCorekit (v4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 4.0.0 — 2026-06-21
+
+### Breaking Changes
+- Entry-point class `FlutterCore` → **`FlutterCorekit`**, to match the package
+  name. Update call sites: `FlutterCorekit.initialize(...)`,
+  `FlutterCorekit.dioClient`, `FlutterCorekit.secureStorage`,
+  `FlutterCorekit.resetInitialization()`.
+
+---
+
 ## 3.0.0 — 2026-06-21
 
 ### Breaking Changes — identifier renames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## 4.0.0 — 2026-06-21
-
-### Breaking Changes
-- Entry-point class `FlutterCore` → **`FlutterCorekit`**, to match the package
-  name. Update call sites: `FlutterCorekit.initialize(...)`,
-  `FlutterCorekit.dioClient`, `FlutterCorekit.secureStorage`,
-  `FlutterCorekit.resetInitialization()`.
-
----
-
 ## 3.0.0 — 2026-06-21
 
 ### Breaking Changes — identifier renames
 
 Public identifiers were renamed so each name reflects its value/role. Update call sites accordingly:
 
-- `FlutterCore.localStorage` → `FlutterCore.secureStorage`; `FlutterCore.cleanup()` → `resetInitialization()`
+- Entry-point class `FlutterCore` → `FlutterCorekit` (matches the package name)
+- `FlutterCorekit.localStorage` → `FlutterCorekit.secureStorage`; `FlutterCorekit.cleanup()` → `resetInitialization()`
 - `ThemeProvider.setThemeMode(bool)` → `setDarkMode(bool)`
 - `Failure.error` field → `Failure.cause` (all subclasses + `NetworkException`)
 - `Result` failure variant `Error` → `ResultError` (avoids shadowing `dart:core.Error`)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ void main() async {
 
   // Initialize theme and core services
   // await ThemeProvider.instance.loadThemeMode();
-  await FlutterCore.initialize(
+  await FlutterCorekit.initialize(
     baseUrl: 'https://jsonplaceholder.typicode.com',
     connectTimeout: 30000,
     receiveTimeout: 30000,
@@ -53,7 +53,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // FlutterCore.initializeUI();
+    // FlutterCorekit.initializeUI();
 
     return ListenableBuilder(
       listenable: ThemeProvider.instance,
@@ -84,7 +84,7 @@ class _HomePageState extends State<HomePage> {
   Future<void> loadData() async {
     setState(() => isLoading = true);
     try {
-      final result = await FlutterCore.dioClient.get('/posts/1');
+      final result = await FlutterCorekit.dioClient.get('/posts/1');
       setState(() {
         response = result.data.toString();
         isLoading = false;

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -1,13 +1,13 @@
 /// Exports core functionalities, services, and UI utilities for Flutter applications.
 ///
 /// This library serves as the main entry point for the `flutter_corekit` package.
-/// It provides the [FlutterCore] class for initializing essential services like
+/// It provides the [FlutterCorekit] class for initializing essential services like
 /// networking and storage, and the [ScreenUtilWrapper] widget for setting up
 /// responsive UI utilities.
 ///
 /// ## Usage
 ///
-/// Before using any services from this package, you must initialize [FlutterCore]:
+/// Before using any services from this package, you must initialize [FlutterCorekit]:
 ///
 /// ```dart
 /// import 'package:flutter_corekit/flutter_corekit.dart';
@@ -18,7 +18,7 @@
 ///   WidgetsFlutterBinding.ensureInitialized();
 ///
 ///   // Initialize Flutter Core services (e.g., network, storage).
-///   await FlutterCore.initialize(baseUrl: 'https://api.example.com');
+///   await FlutterCorekit.initialize(baseUrl: 'https://api.example.com');
 ///
 ///   runApp(MyApp());
 /// }
@@ -59,7 +59,7 @@ import 'src/services/connectivity_service.dart';
 /// The [initialize] method **must** be called before accessing any services.
 ///
 /// Accessing services before initialization will result in a [LateInitializationError].
-class FlutterCore {
+class FlutterCorekit {
   /// A private flag to track whether [initialize] has been called.
   /// This prevents redundant initializations.
   static bool _isInitialized = false;
@@ -102,7 +102,7 @@ class FlutterCore {
   }) async {
     if (_isInitialized) {
       debugPrint(
-          "FlutterCore.initialize() called multiple times. Ignoring subsequent calls.");
+          "FlutterCorekit.initialize() called multiple times. Ignoring subsequent calls.");
       return;
     }
 
@@ -135,10 +135,10 @@ class FlutterCore {
     await ConnectivityService.instance.hasConnection();
 
     _isInitialized = true;
-    debugPrint("FlutterCore initialized successfully.");
+    debugPrint("FlutterCorekit initialized successfully.");
   }
 
-  /// Resets the initialization flag of FlutterCore.
+  /// Resets the initialization flag of FlutterCorekit.
   ///
   /// Primarily for testing, where services may need re-initialization between
   /// tests.
@@ -149,13 +149,13 @@ class FlutterCore {
   static Future<void> resetInitialization() async {
     if (!_isInitialized) {
       debugPrint(
-          "FlutterCore.resetInitialization() called but core is not initialized.");
+          "FlutterCorekit.resetInitialization() called but core is not initialized.");
       return;
     }
 
     _isInitialized = false;
     debugPrint(
-        "FlutterCore cleaned up. Ready for re-initialization if needed.");
+        "FlutterCorekit cleaned up. Ready for re-initialization if needed.");
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_corekit
 description: A comprehensive Flutter core package providing theme management, network handling, secure storage, and UI extensions for Indonesian Flutter apps.
-version: 3.0.0
+version: 4.0.0
 homepage: https://github.com/antsf/flutter_corekit
 repository: https://github.com/antsf/flutter_corekit
 issue_tracker: https://github.com/antsf/flutter_corekit/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_corekit
 description: A comprehensive Flutter core package providing theme management, network handling, secure storage, and UI extensions for Indonesian Flutter apps.
-version: 4.0.0
+version: 3.0.0
 homepage: https://github.com/antsf/flutter_corekit
 repository: https://github.com/antsf/flutter_corekit
 issue_tracker: https://github.com/antsf/flutter_corekit/issues


### PR DESCRIPTION
Renames the entry-point class `FlutterCore` → `FlutterCorekit` to match the package name `flutter_corekit` for consistency.

**Breaking.** Update call sites: `FlutterCorekit.initialize(...)`, `FlutterCorekit.dioClient`, `FlutterCorekit.secureStorage`, `FlutterCorekit.resetInitialization()`.

Touches `lib/core.dart`, `example/lib/main.dart`, CHANGELOG, pubspec (3.0.0 → 4.0.0).

Verified: `flutter analyze` clean · `dart format` clean · 330 tests passing.